### PR TITLE
Add a macro that generate `isCaseBaseName` properties for enum

### DIFF
--- a/MacroExamples.xcodeproj/project.pbxproj
+++ b/MacroExamples.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		3175781D298DBC8700D79290 /* NewTypeMacro.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3175781C298DBC8700D79290 /* NewTypeMacro.swift */; };
 		3175781F298DBFA100D79290 /* NewTypePluginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3175781E298DBFA100D79290 /* NewTypePluginTests.swift */; };
 		31757821298DC4AF00D79290 /* NewType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31757820298DC4AF00D79290 /* NewType.swift */; };
+		371A6719299C241F00E74A8A /* CaseDetectionMacro.swift in Sources */ = {isa = PBXBuildFile; fileRef = 371A6718299C241F00E74A8A /* CaseDetectionMacro.swift */; };
 		BD2CDEE9298B24040015A701 /* Diagnostics.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD2CDEE8298B24040015A701 /* Diagnostics.swift */; };
 		BD2CDEEB298B34730015A701 /* WrapStoredPropertiesMacro.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD2CDEEA298B34730015A701 /* WrapStoredPropertiesMacro.swift */; };
 		BD2CDEED298B4A650015A701 /* DictionaryIndirectionMacro.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD2CDEEC298B4A650015A701 /* DictionaryIndirectionMacro.swift */; };
@@ -73,6 +74,7 @@
 		3175781C298DBC8700D79290 /* NewTypeMacro.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewTypeMacro.swift; sourceTree = "<group>"; };
 		3175781E298DBFA100D79290 /* NewTypePluginTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewTypePluginTests.swift; sourceTree = "<group>"; };
 		31757820298DC4AF00D79290 /* NewType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewType.swift; sourceTree = "<group>"; };
+		371A6718299C241F00E74A8A /* CaseDetectionMacro.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaseDetectionMacro.swift; sourceTree = "<group>"; };
 		BD2CDEE8298B24040015A701 /* Diagnostics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Diagnostics.swift; sourceTree = "<group>"; };
 		BD2CDEEA298B34730015A701 /* WrapStoredPropertiesMacro.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WrapStoredPropertiesMacro.swift; sourceTree = "<group>"; };
 		BD2CDEEC298B4A650015A701 /* DictionaryIndirectionMacro.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryIndirectionMacro.swift; sourceTree = "<group>"; };
@@ -139,6 +141,7 @@
 				BD2CDEEC298B4A650015A701 /* DictionaryIndirectionMacro.swift */,
 				3175781C298DBC8700D79290 /* NewTypeMacro.swift */,
 				BD7324B729989178009C6A08 /* AddCompletionHandlerMacro.swift */,
+				371A6718299C241F00E74A8A /* CaseDetectionMacro.swift */,
 			);
 			path = MacroExamplesPlugin;
 			sourceTree = "<group>";
@@ -380,6 +383,7 @@
 			files = (
 				BD841F82294CE1F600DA4D81 /* AddBlocker.swift in Sources */,
 				BD2CDEEB298B34730015A701 /* WrapStoredPropertiesMacro.swift in Sources */,
+				371A6719299C241F00E74A8A /* CaseDetectionMacro.swift in Sources */,
 				BD752BE5294D3BEC00D00A2E /* WarningMacro.swift in Sources */,
 				3175781D298DBC8700D79290 /* NewTypeMacro.swift in Sources */,
 				BDF5AFF82947E95C00FA119B /* StringifyMacro.swift in Sources */,

--- a/MacroExamples/main.swift
+++ b/MacroExamples/main.swift
@@ -44,6 +44,18 @@ struct Point {
   var y: Int = 2
 }
 
+@CaseDetection
+enum Pet {
+  case dog
+  case cat(curious: Bool)
+  case parrot
+  case snake
+}
+
+let pet: Pet = .cat(curious: true)
+print("Pet is dog: \(pet.isDog)"
+print("Pet is cat: \(pet.isCat)")
+
 var point = Point()
 print("Point storage begins as an empty dictionary: \(point)")
 print("Default value for point.x: \(point.x)")

--- a/MacroExamplesLib/Macros.swift
+++ b/MacroExamplesLib/Macros.swift
@@ -92,3 +92,6 @@ public macro ObservableProperty() = #externalMacro(module: "MacroExamplesPlugin"
 @attached(peer)
 public macro addCompletionHandler() =
     #externalMacro(module: "MacroExamplesPlugin", type: "AddCompletionHandlerMacro")
+
+@attached(member)
+public macro CaseDetection() = #externalMacro(module: "MacroExamplesPlugin", type: "CaseDetectionMacro")

--- a/MacroExamplesPlugin/CaseDetectionMacro.swift
+++ b/MacroExamplesPlugin/CaseDetectionMacro.swift
@@ -1,0 +1,39 @@
+import SwiftSyntax
+import SwiftSyntaxMacros
+
+extension TokenSyntax {
+  fileprivate var initialUppercased: String {
+    let name = self.text
+    guard let initial = name.first else {
+      return name
+    }
+
+    return "\(initial.uppercased())\(name.dropFirst())"
+  }
+}
+
+public struct CaseDetectionMacro: MemberMacro {
+  public static func expansion<
+    Declaration: DeclGroupSyntax, Context: MacroExpansionContext
+  >(
+    of node: AttributeSyntax,
+    providingMembersOf declaration: Declaration,
+    in context: Context
+  ) throws -> [DeclSyntax] {
+    declaration.members.members
+      .compactMap { $0.decl.as(EnumCaseDeclSyntax.self) }
+      .map { $0.elements.first!.identifier }
+      .map { ($0, $0.initialUppercased) }
+      .map { original, uppercased in
+        """
+        var is\(raw: uppercased): Bool {
+          if case let .\(raw: original) = self {
+            return true
+          }
+
+          return false
+        }
+        """
+      }
+  }
+}


### PR DESCRIPTION
A small macro.

Given a enum definition with case name `foo`, `bar`... generate computed property `isFoo`, `isBar` that returns a bool to indicate whether the enum value has the corresponding case.

This has been a somewhat frequently requested language feature. Therefore I think it makes a interesting showcase for member macro.