### PR TITLE
Add @addAsync peer Macro

### DIFF
--- a/MacroExamples.xcodeproj/project.pbxproj
+++ b/MacroExamples.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1D682A92299CE4C6006F9F78 /* AddAsyncMacro.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D682A91299CE4C6006F9F78 /* AddAsyncMacro.swift */; };
 		3175781D298DBC8700D79290 /* NewTypeMacro.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3175781C298DBC8700D79290 /* NewTypeMacro.swift */; };
 		3175781F298DBFA100D79290 /* NewTypePluginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3175781E298DBFA100D79290 /* NewTypePluginTests.swift */; };
 		31757821298DC4AF00D79290 /* NewType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31757820298DC4AF00D79290 /* NewType.swift */; };
@@ -71,6 +72,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		1D682A91299CE4C6006F9F78 /* AddAsyncMacro.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddAsyncMacro.swift; sourceTree = "<group>"; };
 		3175781C298DBC8700D79290 /* NewTypeMacro.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewTypeMacro.swift; sourceTree = "<group>"; };
 		3175781E298DBFA100D79290 /* NewTypePluginTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewTypePluginTests.swift; sourceTree = "<group>"; };
 		31757820298DC4AF00D79290 /* NewType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewType.swift; sourceTree = "<group>"; };
@@ -142,6 +144,7 @@
 				3175781C298DBC8700D79290 /* NewTypeMacro.swift */,
 				BD7324B729989178009C6A08 /* AddCompletionHandlerMacro.swift */,
 				371A6718299C241F00E74A8A /* CaseDetectionMacro.swift */,
+				1D682A91299CE4C6006F9F78 /* AddAsyncMacro.swift */,
 			);
 			path = MacroExamplesPlugin;
 			sourceTree = "<group>";
@@ -392,6 +395,7 @@
 				BD2CDEED298B4A650015A701 /* DictionaryIndirectionMacro.swift in Sources */,
 				BD752BE7294D461B00D00A2E /* FontLiteralMacro.swift in Sources */,
 				BD7324B829989178009C6A08 /* AddCompletionHandlerMacro.swift in Sources */,
+				1D682A92299CE4C6006F9F78 /* AddAsyncMacro.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/MacroExamples/main.swift
+++ b/MacroExamples/main.swift
@@ -53,7 +53,7 @@ enum Pet {
 }
 
 let pet: Pet = .cat(curious: true)
-print("Pet is dog: \(pet.isDog)"
+print("Pet is dog: \(pet.isDog)")
 print("Pet is cat: \(pet.isCat)")
 
 var point = Point()
@@ -116,6 +116,25 @@ struct MyStruct {
   func f(a: Int, for b: String, _ value: Double) async -> String {
     return b
   }
+  
+  @addAsync
+  func c(a: Int, for b: String, _ value: Double, completionBlock: @escaping (String) -> Void) -> Void {
+    completionBlock("a: \(a), b: \(b), value: \(value)")
+  }
+  
+  @addAsync
+  func d(a: Int, for b: String, _ value: Double, completionBlock: @escaping () -> Void) -> Void {
+    completionBlock()
+  }
+}
+
+
+Task {
+  let myStruct = MyStruct()
+  let a = await myStruct.c(a: 5, for: "Test", 20)
+  print(a)
+  
+  await myStruct.d(a: 10, for: "value", 40)
 }
 
 MyStruct().f(a: 1, for: "hello", 3.14159) { result in

--- a/MacroExamplesLib/Macros.swift
+++ b/MacroExamplesLib/Macros.swift
@@ -93,5 +93,9 @@ public macro ObservableProperty() = #externalMacro(module: "MacroExamplesPlugin"
 public macro addCompletionHandler() =
     #externalMacro(module: "MacroExamplesPlugin", type: "AddCompletionHandlerMacro")
 
+@attached(peer)
+public macro addAsync() =
+    #externalMacro(module: "MacroExamplesPlugin", type: "AddAsyncMacro")
+
 @attached(member)
 public macro CaseDetection() = #externalMacro(module: "MacroExamplesPlugin", type: "CaseDetectionMacro")

--- a/MacroExamplesPlugin/AddAsyncMacro.swift
+++ b/MacroExamplesPlugin/AddAsyncMacro.swift
@@ -1,0 +1,131 @@
+import SwiftSyntax
+import SwiftSyntaxMacros
+
+
+public struct AddAsyncMacro: PeerMacro {
+  public static func expansion<
+    Context: MacroExpansionContext,
+    Declaration: DeclSyntaxProtocol
+  >(
+    of node: AttributeSyntax,
+    providingPeersOf declaration: Declaration,
+    in context: Context
+  ) throws -> [DeclSyntax] {
+  
+    // Only on functions at the moment.
+    guard let funcDecl = declaration.as(FunctionDeclSyntax.self) else {
+      throw CustomError.message("@addAsync only works on functions")
+    }
+    
+    // This only makes sense for non async functions.
+    if funcDecl.signature.effectSpecifiers?.asyncSpecifier != nil {
+      throw CustomError.message(
+        "@addAsync requires an non async function"
+      )
+    }
+    
+    // This only makes sense void functions
+    if funcDecl.signature.output?.returnType.with(\.leadingTrivia, []).with(\.trailingTrivia, []).description != "Void" {
+      throw CustomError.message(
+        "@addAsync requires an function that returns void"
+      )
+    }
+    
+    // Requires a completion handler block as last parameter
+    guard let completionHandlerParameterAttribute = funcDecl.signature.input.parameterList.last?.type?.as(AttributedTypeSyntax.self),
+    let completionHandlerParameter = completionHandlerParameterAttribute.baseType.as(FunctionTypeSyntax.self) else {
+      throw CustomError.message(
+        "@addAsync requires an function that has a completion handler as last parameter"
+      )
+    }
+    
+    // Completion handler needs to return Void
+    if completionHandlerParameter.output.returnType.with(\.leadingTrivia, []).with(\.trailingTrivia, []).description != "Void" {
+      throw CustomError.message(
+        "@addAsync requires an function that has a completion handler that returns Void"
+      )
+    }
+    
+    let returnType = completionHandlerParameter.arguments.first?.type
+    
+    // Remove completionHandler and comma from the previous parameter
+    var newParameterList = funcDecl.signature.input.parameterList.removingLast()
+    let newParameterListLastParameter = newParameterList.last!
+    newParameterList = newParameterList.removingLast()
+    newParameterList = newParameterList.appending(newParameterListLastParameter.with(\.trailingTrivia, []).with(\.trailingComma, nil))
+    
+    
+    // Drop the @addAsync attribute from the new declaration.
+    let newAttributeList = AttributeListSyntax(
+      funcDecl.attributes?.filter {
+        guard case let .attribute(attribute) = $0,
+              let attributeType = attribute.attributeName.as(SimpleTypeIdentifierSyntax.self),
+              let nodeType = node.attributeName.as(SimpleTypeIdentifierSyntax.self)
+        else {
+          return true
+        }
+        
+        return attributeType.name.text != nodeType.name.text
+      } ?? []
+    )
+    
+    let callArguments: [String] = try newParameterList.map { param in
+      guard let argName = param.secondName ?? param.firstName else {
+        throw CustomError.message(
+          "@addAsync argument must have a name"
+        )
+      }
+      
+      if let paramName = param.firstName, paramName.text != "_" {
+        return "\(paramName.text): \(argName.text)"
+      }
+      
+      return "\(argName.text)"
+    }
+
+    let newBody: ExprSyntax =
+      """
+      
+        await withCheckedContinuation { continuation in
+          \(funcDecl.identifier)(\(raw: callArguments.joined(separator: ", "))) { \(returnType != nil ? "returnValue in" : "")
+            continuation.resume(returning: \(returnType != nil ? "returnValue" : "()"))
+          }
+        }
+      
+      """
+
+    let newFunc =
+    funcDecl
+      .with(
+        \.signature,
+         funcDecl.signature
+          .with(
+            \.effectSpecifiers,
+             DeclEffectSpecifiersSyntax(leadingTrivia: .space, asyncSpecifier: "async")  // add async
+          )
+          .with(\.output, returnType != nil ? ReturnClauseSyntax(leadingTrivia: .space, returnType: returnType!.with(\.leadingTrivia, .space)) : nil)  // add result type
+          .with(
+            \.input,
+             funcDecl.signature.input.with(\.parameterList, newParameterList) // drop completion handler
+              .with(\.trailingTrivia, [])
+          )
+      )
+      .with(
+        \.body,
+         CodeBlockSyntax(
+          leftBrace: .leftBraceToken(leadingTrivia: .space),
+          statements: CodeBlockItemListSyntax(
+            [CodeBlockItemSyntax(item: .expr(newBody))]
+          ),
+          rightBrace: .rightBraceToken(leadingTrivia: .newline)
+         )
+      )
+      .with(\.attributes, newAttributeList)
+      .with(\.leadingTrivia, .newlines(2))
+    
+    return [DeclSyntax(newFunc)]
+  }
+}
+
+
+


### PR DESCRIPTION
Small macro that I did to learn how Macros work :D. 

Basically does the inverse of `AddCompletionHandlerMacro`. 

AddCompletionHandlerMacro gets an async function and adds a function with a completion handler
AddAsync gets a function with a completion handler and adds a async function

I think it can be helpful for codebases with legacy code that still use completion handlers and want to migrate to async await.

