### PR TITLE
@AddAsync to support Result and @CustomCodable

### DIFF
--- a/MacroExamples.xcodeproj/project.pbxproj
+++ b/MacroExamples.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		1D682A92299CE4C6006F9F78 /* AddAsyncMacro.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D682A91299CE4C6006F9F78 /* AddAsyncMacro.swift */; };
+		1D682A94299E2FFB006F9F78 /* CodableKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D682A93299E2FFB006F9F78 /* CodableKey.swift */; };
+		1D682A96299E3313006F9F78 /* CustomCodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D682A95299E3313006F9F78 /* CustomCodable.swift */; };
 		3175781D298DBC8700D79290 /* NewTypeMacro.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3175781C298DBC8700D79290 /* NewTypeMacro.swift */; };
 		3175781F298DBFA100D79290 /* NewTypePluginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3175781E298DBFA100D79290 /* NewTypePluginTests.swift */; };
 		31757821298DC4AF00D79290 /* NewType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31757820298DC4AF00D79290 /* NewType.swift */; };
@@ -73,6 +75,8 @@
 
 /* Begin PBXFileReference section */
 		1D682A91299CE4C6006F9F78 /* AddAsyncMacro.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddAsyncMacro.swift; sourceTree = "<group>"; };
+		1D682A93299E2FFB006F9F78 /* CodableKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodableKey.swift; sourceTree = "<group>"; };
+		1D682A95299E3313006F9F78 /* CustomCodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomCodable.swift; sourceTree = "<group>"; };
 		3175781C298DBC8700D79290 /* NewTypeMacro.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewTypeMacro.swift; sourceTree = "<group>"; };
 		3175781E298DBFA100D79290 /* NewTypePluginTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewTypePluginTests.swift; sourceTree = "<group>"; };
 		31757820298DC4AF00D79290 /* NewType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewType.swift; sourceTree = "<group>"; };
@@ -145,6 +149,8 @@
 				BD7324B729989178009C6A08 /* AddCompletionHandlerMacro.swift */,
 				371A6718299C241F00E74A8A /* CaseDetectionMacro.swift */,
 				1D682A91299CE4C6006F9F78 /* AddAsyncMacro.swift */,
+				1D682A93299E2FFB006F9F78 /* CodableKey.swift */,
+				1D682A95299E3313006F9F78 /* CustomCodable.swift */,
 			);
 			path = MacroExamplesPlugin;
 			sourceTree = "<group>";
@@ -386,12 +392,14 @@
 			files = (
 				BD841F82294CE1F600DA4D81 /* AddBlocker.swift in Sources */,
 				BD2CDEEB298B34730015A701 /* WrapStoredPropertiesMacro.swift in Sources */,
+				1D682A94299E2FFB006F9F78 /* CodableKey.swift in Sources */,
 				371A6719299C241F00E74A8A /* CaseDetectionMacro.swift in Sources */,
 				BD752BE5294D3BEC00D00A2E /* WarningMacro.swift in Sources */,
 				3175781D298DBC8700D79290 /* NewTypeMacro.swift in Sources */,
 				BDF5AFF82947E95C00FA119B /* StringifyMacro.swift in Sources */,
 				EC21BDEB298D9F9900D585C6 /* ObservableMacro.swift in Sources */,
 				BD2CDEE9298B24040015A701 /* Diagnostics.swift in Sources */,
+				1D682A96299E3313006F9F78 /* CustomCodable.swift in Sources */,
 				BD2CDEED298B4A650015A701 /* DictionaryIndirectionMacro.swift in Sources */,
 				BD752BE7294D461B00D00A2E /* FontLiteralMacro.swift in Sources */,
 				BD7324B829989178009C6A08 /* AddCompletionHandlerMacro.swift in Sources */,

--- a/MacroExamples/main.swift
+++ b/MacroExamples/main.swift
@@ -1,5 +1,6 @@
 
 import MacroExamplesLib
+import Foundation
 
 let x = 1
 let y = 2
@@ -126,15 +127,25 @@ struct MyStruct {
   func d(a: Int, for b: String, _ value: Double, completionBlock: @escaping (Bool) -> Void) -> Void {
     completionBlock(true)
   }
+}
+
+@CustomCodable
+struct CustomCodableString: Codable {
   
+  @CodableKey(name: "OtherName")
+  var propertyWithOtherName: String
   
+  var propertyWithSameName: Bool
+ 
+  func randomFunction() {
+    
+  }
 }
 
 
 Task {
   let myStruct = MyStruct()
   let a = try? await myStruct.c(a: 5, for: "Test", 20)
-  print(a)
   
   await myStruct.d(a: 10, for: "value", 40)
 }
@@ -142,3 +153,16 @@ Task {
 MyStruct().f(a: 1, for: "hello", 3.14159) { result in
   print("Eventually received \(result + "!")")
 }
+
+
+let json = """
+{
+  "OtherName": "Name",
+  "propertyWithSameName": true
+}
+
+""".data(using: .utf8)!
+
+let jsonDecoder = JSONDecoder()
+let product = try jsonDecoder.decode(CustomCodableString.self, from: json)
+print(product.propertyWithOtherName)

--- a/MacroExamples/main.swift
+++ b/MacroExamples/main.swift
@@ -118,20 +118,22 @@ struct MyStruct {
   }
   
   @addAsync
-  func c(a: Int, for b: String, _ value: Double, completionBlock: @escaping (String) -> Void) -> Void {
-    completionBlock("a: \(a), b: \(b), value: \(value)")
+  func c(a: Int, for b: String, _ value: Double, completionBlock: @escaping (Result<String, Error>) -> Void) -> Void {
+    completionBlock(.success("a: \(a), b: \(b), value: \(value)"))
   }
   
   @addAsync
-  func d(a: Int, for b: String, _ value: Double, completionBlock: @escaping () -> Void) -> Void {
-    completionBlock()
+  func d(a: Int, for b: String, _ value: Double, completionBlock: @escaping (Bool) -> Void) -> Void {
+    completionBlock(true)
   }
+  
+  
 }
 
 
 Task {
   let myStruct = MyStruct()
-  let a = await myStruct.c(a: 5, for: "Test", 20)
+  let a = try? await myStruct.c(a: 5, for: "Test", 20)
   print(a)
   
   await myStruct.d(a: 10, for: "value", 40)

--- a/MacroExamplesLib/Macros.swift
+++ b/MacroExamplesLib/Macros.swift
@@ -99,3 +99,10 @@ public macro addAsync() =
 
 @attached(member)
 public macro CaseDetection() = #externalMacro(module: "MacroExamplesPlugin", type: "CaseDetectionMacro")
+
+
+@attached(member)
+public macro CodableKey(name: String) = #externalMacro(module: "MacroExamplesPlugin", type: "CodableKey")
+
+@attached(member)
+public macro CustomCodable() = #externalMacro(module: "MacroExamplesPlugin", type: "CustomCodable")

--- a/MacroExamplesPlugin/CodableKey.swift
+++ b/MacroExamplesPlugin/CodableKey.swift
@@ -1,0 +1,8 @@
+//
+//  CodableKey.swift
+//  MacroExamplesPlugin
+//
+//  Created by Bruno Mazzo on 16/2/2023.
+//
+
+import Foundation

--- a/MacroExamplesPlugin/CodableKey.swift
+++ b/MacroExamplesPlugin/CodableKey.swift
@@ -1,8 +1,15 @@
-//
-//  CodableKey.swift
-//  MacroExamplesPlugin
-//
-//  Created by Bruno Mazzo on 16/2/2023.
-//
+import SwiftSyntax
+import SwiftSyntaxMacros
 
-import Foundation
+public struct CodableKey: MemberMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    providingMembersOf declaration: some DeclGroupSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+      // Does nothing, used only to decorate members with data
+      return []
+  }
+
+
+}

--- a/MacroExamplesPlugin/CustomCodable.swift
+++ b/MacroExamplesPlugin/CustomCodable.swift
@@ -1,0 +1,47 @@
+import SwiftSyntax
+import SwiftSyntaxMacros
+
+public struct CustomCodable: MemberMacro {
+  
+  public static func expansion(
+    of node: AttributeSyntax,
+    providingMembersOf declaration: some DeclGroupSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    
+    let memberList = declaration.members.members
+    
+    let cases = memberList.compactMap({ member -> String? in
+      // is a property
+      guard
+        let propertyName = member.decl.as(VariableDeclSyntax.self)?.bindings.first?.pattern.as(IdentifierPatternSyntax.self)?.identifier.text else {
+        return nil
+      }
+      
+      // if it has a CodableKey macro on it
+      if let customKeyMacro = member.decl.as(VariableDeclSyntax.self)?.attributes?.first(where: { element in
+        element.as(AttributeSyntax.self)?.attributeName.as(SimpleTypeIdentifierSyntax.self)?.description == "CodableKey"
+      }) {
+        
+        // Uses the value in the Macro
+        let customKeyValue = customKeyMacro.as(AttributeSyntax.self)!.argument!.as(TupleExprElementListSyntax.self)!.first!.expression
+        
+        return "case \(propertyName) = \(customKeyValue)"
+      } else {
+        return "case \(propertyName)"
+      }
+    })
+    
+    let codingKeys: DeclSyntax = """
+    
+      enum CodingKeys: String, CodingKey {
+        \(raw: cases.joined(separator: "\n"))
+      }
+
+    """
+    
+    return [
+      codingKeys
+    ]
+  }
+}


### PR DESCRIPTION
I just added another thing to the AddAsync macro. Now it supports `Result` and convert completion blocks that have it to `async throw` functions.

Then I played a little with member macros, and created a CustomCodable and CodableKey macros. CustomCodable uses CodableKey to mark properties that we want to change the name. So you don't need to implement CodableKeys manually. I will try to implement default values too later.