### PR TITLE
Add OptionSet macro to help build option sets

### DIFF
--- a/MacroExamples.xcodeproj/project.pbxproj
+++ b/MacroExamples.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		BD2CDEE9298B24040015A701 /* Diagnostics.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD2CDEE8298B24040015A701 /* Diagnostics.swift */; };
 		BD2CDEEB298B34730015A701 /* WrapStoredPropertiesMacro.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD2CDEEA298B34730015A701 /* WrapStoredPropertiesMacro.swift */; };
 		BD2CDEED298B4A650015A701 /* DictionaryIndirectionMacro.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD2CDEEC298B4A650015A701 /* DictionaryIndirectionMacro.swift */; };
+		BD48319329AFF87200F3123A /* OptionSetMacro.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD48319229AFF87200F3123A /* OptionSetMacro.swift */; };
 		BD7324B829989178009C6A08 /* AddCompletionHandlerMacro.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD7324B729989178009C6A08 /* AddCompletionHandlerMacro.swift */; };
 		BD752BE5294D3BEC00D00A2E /* WarningMacro.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD752BE4294D3BEC00D00A2E /* WarningMacro.swift */; };
 		BD752BE7294D461B00D00A2E /* FontLiteralMacro.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD752BE6294D461B00D00A2E /* FontLiteralMacro.swift */; };
@@ -85,6 +86,7 @@
 		BD2CDEEA298B34730015A701 /* WrapStoredPropertiesMacro.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WrapStoredPropertiesMacro.swift; sourceTree = "<group>"; };
 		BD2CDEEC298B4A650015A701 /* DictionaryIndirectionMacro.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryIndirectionMacro.swift; sourceTree = "<group>"; };
 		BD3FE05C296611F200426C82 /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
+		BD48319229AFF87200F3123A /* OptionSetMacro.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptionSetMacro.swift; sourceTree = "<group>"; };
 		BD7324B729989178009C6A08 /* AddCompletionHandlerMacro.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddCompletionHandlerMacro.swift; sourceTree = "<group>"; };
 		BD752BE4294D3BEC00D00A2E /* WarningMacro.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WarningMacro.swift; sourceTree = "<group>"; };
 		BD752BE6294D461B00D00A2E /* FontLiteralMacro.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontLiteralMacro.swift; sourceTree = "<group>"; };
@@ -151,6 +153,7 @@
 				1D682A91299CE4C6006F9F78 /* AddAsyncMacro.swift */,
 				1D682A93299E2FFB006F9F78 /* CodableKey.swift */,
 				1D682A95299E3313006F9F78 /* CustomCodable.swift */,
+				BD48319229AFF87200F3123A /* OptionSetMacro.swift */,
 			);
 			path = MacroExamplesPlugin;
 			sourceTree = "<group>";
@@ -403,6 +406,7 @@
 				BD2CDEED298B4A650015A701 /* DictionaryIndirectionMacro.swift in Sources */,
 				BD752BE7294D461B00D00A2E /* FontLiteralMacro.swift in Sources */,
 				BD7324B829989178009C6A08 /* AddCompletionHandlerMacro.swift in Sources */,
+				BD48319329AFF87200F3123A /* OptionSetMacro.swift in Sources */,
 				1D682A92299CE4C6006F9F78 /* AddAsyncMacro.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -536,6 +540,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = macosx;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_INSTALL_OBJC_HEADER = NO;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 			};
 			name = Debug;
@@ -589,6 +594,7 @@
 				MTL_FAST_MATH = YES;
 				SDKROOT = macosx;
 				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_INSTALL_OBJC_HEADER = NO;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
 			};
 			name = Release;
@@ -599,6 +605,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				OTHER_SWIFT_FLAGS = "-Xfrontend -enable-experimental-feature -Xfrontend Macros -Xfrontend -load-plugin-library -Xfrontend ${BUILD_DIR}/${CONFIGURATION}/libMacroExamplesPlugin.dylib -Xfrontend -dump-macro-expansions";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				"SWIFT_OPTIMIZATION_LEVEL[arch=*]" = "-Onone";
 				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;

--- a/MacroExamples/main.swift
+++ b/MacroExamples/main.swift
@@ -167,8 +167,28 @@ let jsonDecoder = JSONDecoder()
 let product = try jsonDecoder.decode(CustomCodableString.self, from: json)
 print(product.propertyWithOtherName)
 
-@OptionSet
+
 struct ShippingOptions {
+  typealias RawValue = Int
+  
+  var rawValue: RawValue
+  
+  init() { self.rawValue = 0 }
+  
+  init(rawValue: RawValue) { self.rawValue = rawValue }
+  
+  static let nextDay: Self =
+  Self(rawValue: 1 << Options.nextDay.rawValue)
+  
+  static let secondDay: Self =
+  Self(rawValue: 1 << Options.secondDay.rawValue)
+  
+  static let priority: Self =
+  Self(rawValue: 1 << Options.priority.rawValue)
+  
+  static let standard: Self =
+  Self(rawValue: 1 << Options.standard.rawValue)
+  
   private enum Options: Int {
     case nextDay
     case secondDay
@@ -179,3 +199,6 @@ struct ShippingOptions {
   static let express: ShippingOptions = [.nextDay, .secondDay]
   static let all: ShippingOptions = [.express, .priority, .standard]
 }
+
+extension ShippingOptions : OptionSet  {}
+

--- a/MacroExamples/main.swift
+++ b/MacroExamples/main.swift
@@ -166,3 +166,16 @@ let json = """
 let jsonDecoder = JSONDecoder()
 let product = try jsonDecoder.decode(CustomCodableString.self, from: json)
 print(product.propertyWithOtherName)
+
+@OptionSet
+struct ShippingOptions {
+  private enum Options: Int {
+    case nextDay
+    case secondDay
+    case priority
+    case standard
+  }
+
+  static let express: ShippingOptions = [.nextDay, .secondDay]
+  static let all: ShippingOptions = [.express, .priority, .standard]
+}

--- a/MacroExamplesLib/Macros.swift
+++ b/MacroExamplesLib/Macros.swift
@@ -116,7 +116,7 @@ public macro CustomCodable() = #externalMacro(module: "MacroExamplesPlugin", typ
 ///    along with the necessary `RawType` typealias and initializers to satisfy
 ///    the `OptionSet` protocol.
 ///   2. Introducing static properties for each of the cases within the `Options`
-///    enum, of the type of the
+///    enum, of the type of the struct.
 ///
 /// The `Options` enum must have a raw value, where its case elements
 /// each indicate a different option in the resulting option set. For example,

--- a/MacroExamplesLib/Macros.swift
+++ b/MacroExamplesLib/Macros.swift
@@ -106,3 +106,31 @@ public macro CodableKey(name: String) = #externalMacro(module: "MacroExamplesPlu
 
 @attached(member)
 public macro CustomCodable() = #externalMacro(module: "MacroExamplesPlugin", type: "CustomCodable")
+
+/// Create an option set from a struct that contains a nested `Options` enum.
+///
+/// Attach this macro to a struct that contains a nested `Options` enum
+/// with an integer raw value. The struct will be transformed to conform to
+/// `OptionSet` by
+///   1. Introducing a `rawValue` stored property to track which options are set,
+///    along with the necessary `RawType` typealias and initializers to satisfy
+///    the `OptionSet` protocol.
+///   2. Introducing static properties for each of the cases within the `Options`
+///    enum, of the type of the
+///
+/// The `Options` enum must have a raw value, where its case elements
+/// each indicate a different option in the resulting option set. For example,
+/// the struct and its nested `Options` enum could look like this:
+///
+///     @OptionSet
+///     struct ShippingOptions {
+///       private enum Options: Int {
+///         case nextDay
+///         case secondDay
+///         case priority
+///         case standard
+///       }
+///     }
+@attached(member)
+@attached(conformance)
+public macro OptionSet() = #externalMacro(module: "MacroExamplesPlugin", type: "OptionSetMacro")

--- a/MacroExamplesPlugin/DictionaryIndirectionMacro.swift
+++ b/MacroExamplesPlugin/DictionaryIndirectionMacro.swift
@@ -30,7 +30,6 @@ extension DictionaryStorageMacro: AccessorMacro {
       throw CustomError.message("stored property must have an initializer")
     }
 
-    print(varDecl.recursiveDescription)
     return [
       """
 

--- a/MacroExamplesPlugin/NewTypeMacro.swift
+++ b/MacroExamplesPlugin/NewTypeMacro.swift
@@ -40,7 +40,7 @@ extension NewTypeMacro: MemberMacro {
 }
 
 extension DeclModifierSyntax {
-  fileprivate var isNeededAccessLevelModifier: Bool {
+  var isNeededAccessLevelModifier: Bool {
     switch self.name.tokenKind {
     case .keyword(.public): return true
     default: return false
@@ -50,7 +50,7 @@ extension DeclModifierSyntax {
 
 extension SyntaxStringInterpolation {
   // It would be nice for SwiftSyntaxBuilder to provide this out-of-the-box.
-  fileprivate mutating func appendInterpolation<Node: SyntaxProtocol>(_ node: Node?) {
+  mutating func appendInterpolation<Node: SyntaxProtocol>(_ node: Node?) {
     if let node {
       appendInterpolation(node)
     }

--- a/MacroExamplesPlugin/OptionSetMacro.swift
+++ b/MacroExamplesPlugin/OptionSetMacro.swift
@@ -1,0 +1,178 @@
+import SwiftDiagnostics
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+
+enum OptionSetMacroDiagnostic {
+  case requiresStruct
+  case requiresStringLiteral(String)
+  case requiresOptionsEnum(String)
+  case requiresOptionsEnumRawValue(String)
+}
+
+extension OptionSetMacroDiagnostic: DiagnosticMessage {
+  func diagnose(at node: some SyntaxProtocol) -> Diagnostic {
+    Diagnostic(node: Syntax(node), message: self)
+  }
+
+  var message: String {
+    switch self {
+    case .requiresStruct:
+      return "'OptionSet' macro can only be applied to a struct"
+
+    case .requiresStringLiteral(let name):
+      return "'OptionSet' macro argument \(name) must be a string literal"
+
+    case .requiresOptionsEnum(let name):
+      return "'OptionSet' macro requires nested options enum '\(name)'"
+
+    case .requiresOptionsEnumRawValue(let name):
+      return "'\(name)' enum requires an integer raw value type"
+    }
+  }
+
+  var severity: DiagnosticSeverity { .error }
+
+  var diagnosticID: MessageID {
+    MessageID(domain: "Swift", id: "OptionSet.\(self)")
+  }
+}
+
+
+/// The label used for the OptionSet macro argument that provides the name of
+/// the nested options enum.
+private let optionsEnumNameArgumentLabel = "optionsName"
+
+/// The default name used for the nested "Options" enum. This should
+/// eventually be overridable.
+private let defaultOptionsEnumName = "Options"
+
+extension TupleExprElementListSyntax {
+  /// Retrieve the first element with the given label.
+  func first(labeled name: String) -> Element? {
+    return first { element in
+      if let label = element.label, label.text == name {
+        return true
+      }
+
+      return false
+    }
+  }
+}
+
+public struct OptionSetMacro {
+  /// Decodes the arguments to the macro expansion.
+  ///
+  /// - Returns: the important arguments used by the various roles of this
+  /// macro inhabits, or nil if an error occurred.
+  static func decodeExpansion(
+    of attribute: AttributeSyntax,
+    attachedTo decl: some DeclGroupSyntax,
+    in context: some MacroExpansionContext
+  ) -> (StructDeclSyntax, EnumDeclSyntax, TypeSyntax)? {
+    // Determine the name of the options enum.
+    let optionsEnumName: String
+    if case let .argumentList(arguments) = attribute.argument,
+       let optionEnumNameArg = arguments.first(labeled: optionsEnumNameArgumentLabel) {
+      // We have a options name; make sure it is a string literal.
+      guard let stringLiteral = optionEnumNameArg.expression.as(StringLiteralExprSyntax.self),
+         stringLiteral.segments.count == 1,
+          case let .stringSegment(optionsEnumNameString)? = stringLiteral.segments.first else {
+        context.diagnose(OptionSetMacroDiagnostic.requiresStringLiteral(optionsEnumNameArgumentLabel).diagnose(at: optionEnumNameArg.expression))
+        return nil
+      }
+
+      optionsEnumName = optionsEnumNameString.content.text
+    } else {
+      optionsEnumName = defaultOptionsEnumName
+    }
+
+    // Only apply to structs.
+    guard let structDecl = decl.as(StructDeclSyntax.self) else {
+      context.diagnose(OptionSetMacroDiagnostic.requiresStruct.diagnose(at: decl))
+      return nil
+    }
+
+    // Find the option enum within the struct.
+    guard let optionsEnum = decl.members.members.compactMap({ member in
+      if let enumDecl = member.decl.as(EnumDeclSyntax.self),
+         enumDecl.identifier.text == optionsEnumName {
+        return enumDecl
+      }
+
+      return nil
+    }).first else {
+      context.diagnose(OptionSetMacroDiagnostic.requiresOptionsEnum(optionsEnumName).diagnose(at: decl))
+      return nil
+    }
+
+    // Retrieve the raw type of the enum.
+    guard let rawType = optionsEnum.inheritanceClause?.inheritedTypeCollection.first?.typeName else {
+      context.diagnose(OptionSetMacroDiagnostic.requiresOptionsEnumRawValue(optionsEnumName).diagnose(at: optionsEnum))
+      return nil
+    }
+
+
+    return (structDecl, optionsEnum, rawType)
+  }
+}
+
+extension OptionSetMacro: ConformanceMacro {
+  public static func expansion(
+    of attribute: AttributeSyntax,
+    providingConformancesOf decl: some DeclGroupSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> [(TypeSyntax, GenericWhereClauseSyntax?)] {
+    // Decode the expansion arguments.
+    guard let (structDecl, _, _) = decodeExpansion(of: attribute, attachedTo: decl, in: context) else {
+      return []
+    }
+
+    // If there is an explicit conformance to OptionSet already, don't add one.
+    if let inheritedTypes = structDecl.inheritanceClause?.inheritedTypeCollection,
+       inheritedTypes.contains(where: { inherited in inherited.typeName.trimmedDescription == "OptionSet" }) {
+      return []
+    }
+
+    return [("OptionSet", nil)]
+  }
+}
+
+extension OptionSetMacro: MemberMacro {
+  public static func expansion(
+    of attribute: AttributeSyntax,
+    providingMembersOf decl: some DeclGroupSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    // Decode the expansion arguments.
+    guard let (_, optionsEnum, rawType) = decodeExpansion(of: attribute, attachedTo: decl, in: context) else {
+      return []
+    }
+
+    // Find all of the case elements.
+    let caseElements = optionsEnum.members.members.flatMap { member in
+      guard let caseDecl = member.decl.as(EnumCaseDeclSyntax.self) else {
+        return Array<EnumCaseElementSyntax>()
+      }
+
+      return Array(caseDecl.elements)
+    }
+
+    // Dig out the access control keyword we need.
+    let access = decl.modifiers?.first(where: \.isNeededAccessLevelModifier)
+
+    let staticVars = caseElements.map { (element) -> DeclSyntax in
+      """
+      \(access) static let \(element.identifier): Self =
+        Self(rawValue: 1 << \(optionsEnum.identifier).\(element.identifier).rawValue)
+      """
+    }
+
+    return [
+      "\(access)typealias RawValue = \(rawType)",
+      "\(access)var rawValue: RawValue",
+      "\(access)init() { self.rawValue = 0 }",
+      "\(access)init(rawValue: RawValue) { self.rawValue = rawValue }",
+    ] + staticVars
+  }
+}

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ There is an active effort to introduce [macros](https://forums.swift.org/t/a-pos
 
 Macros are an experimental feature, so you will need a custom Swift toolchain and some extra compiler flags. The Xcode project in this repository is a good starting point. To use it:
 
-1. Download a [development snapshot](https://www.swift.org/download/#snapshots) of the compiler from Swift.org from February 13, 2023 or later. At present, we only have these working on macOS, but are working to get other platforms working with other build systems.
+1. Download a [development snapshot](https://www.swift.org/download/#snapshots) of the compiler from Swift.org from March 3, 2023 or later. At present, we only have these working on macOS, but are working to get other platforms working with other build systems.
 2. Open the project `MacroExamples.xcodeproj` in Xcode.
 3. Go to the Xcode -> Toolchains menu and select the development toolchain you downloaded.
 4. Make sure the `MacroExamples` scheme is selected, then build and run! If the first build fails, build again--there's something funky going on with the dependencies.
@@ -46,7 +46,5 @@ Once you have both a declaration and an implementation, it's time to use your ma
 
 ## Macros proposals
 
-The introduction of macros into Swift will involve a number of different proposals. Here 
-
-* [Expression macros](https://forums.swift.org/t/pitch-2-expression-macros/61861): Introduces the ability to add macros that transform expressions into other expressions.
+The introduction of macros into Swift will involve a number of different proposals. The [Swift macros dashboard](https://gist.github.com/DougGregor/de840fcf6d6f307792121eee11c0da85) keeps track of all of them.
 


### PR DESCRIPTION
Add an `OptionSet` macro that can be used like this:

```swift
@OptionSet
struct ShippingOptions {
  private enum Options: Int {
    case nextDay
    case secondDay
    case priority
    case standard
  }
}
```

to build a proper option set.