### PR TITLE
Add @MetaEnum macro

### DIFF
--- a/MacroExamples.xcodeproj/project.pbxproj
+++ b/MacroExamples.xcodeproj/project.pbxproj
@@ -14,6 +14,8 @@
 		3175781F298DBFA100D79290 /* NewTypePluginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3175781E298DBFA100D79290 /* NewTypePluginTests.swift */; };
 		31757821298DC4AF00D79290 /* NewType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31757820298DC4AF00D79290 /* NewType.swift */; };
 		371A6719299C241F00E74A8A /* CaseDetectionMacro.swift in Sources */ = {isa = PBXBuildFile; fileRef = 371A6718299C241F00E74A8A /* CaseDetectionMacro.swift */; };
+		88E54A5229B5475400252D99 /* MetaEnumMacro.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88E54A5129B5475400252D99 /* MetaEnumMacro.swift */; };
+		88E54A5429B5520A00252D99 /* MetaEnumMacroTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88E54A5329B5520A00252D99 /* MetaEnumMacroTests.swift */; };
 		BD2CDEE9298B24040015A701 /* Diagnostics.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD2CDEE8298B24040015A701 /* Diagnostics.swift */; };
 		BD2CDEEB298B34730015A701 /* WrapStoredPropertiesMacro.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD2CDEEA298B34730015A701 /* WrapStoredPropertiesMacro.swift */; };
 		BD2CDEED298B4A650015A701 /* DictionaryIndirectionMacro.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD2CDEEC298B4A650015A701 /* DictionaryIndirectionMacro.swift */; };
@@ -82,6 +84,8 @@
 		3175781E298DBFA100D79290 /* NewTypePluginTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewTypePluginTests.swift; sourceTree = "<group>"; };
 		31757820298DC4AF00D79290 /* NewType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewType.swift; sourceTree = "<group>"; };
 		371A6718299C241F00E74A8A /* CaseDetectionMacro.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaseDetectionMacro.swift; sourceTree = "<group>"; };
+		88E54A5129B5475400252D99 /* MetaEnumMacro.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetaEnumMacro.swift; sourceTree = "<group>"; };
+		88E54A5329B5520A00252D99 /* MetaEnumMacroTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetaEnumMacroTests.swift; sourceTree = "<group>"; };
 		BD2CDEE8298B24040015A701 /* Diagnostics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Diagnostics.swift; sourceTree = "<group>"; };
 		BD2CDEEA298B34730015A701 /* WrapStoredPropertiesMacro.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WrapStoredPropertiesMacro.swift; sourceTree = "<group>"; };
 		BD2CDEEC298B4A650015A701 /* DictionaryIndirectionMacro.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryIndirectionMacro.swift; sourceTree = "<group>"; };
@@ -154,6 +158,7 @@
 				1D682A93299E2FFB006F9F78 /* CodableKey.swift */,
 				1D682A95299E3313006F9F78 /* CustomCodable.swift */,
 				BD48319229AFF87200F3123A /* OptionSetMacro.swift */,
+				88E54A5129B5475400252D99 /* MetaEnumMacro.swift */,
 			);
 			path = MacroExamplesPlugin;
 			sourceTree = "<group>";
@@ -212,6 +217,7 @@
 			children = (
 				BDFB14B42948484000708DA6 /* MacroExamplesPluginTest.swift */,
 				3175781E298DBFA100D79290 /* NewTypePluginTests.swift */,
+				88E54A5329B5520A00252D99 /* MetaEnumMacroTests.swift */,
 			);
 			path = MacroExamplesPluginTest;
 			sourceTree = "<group>";
@@ -401,6 +407,7 @@
 				3175781D298DBC8700D79290 /* NewTypeMacro.swift in Sources */,
 				BDF5AFF82947E95C00FA119B /* StringifyMacro.swift in Sources */,
 				EC21BDEB298D9F9900D585C6 /* ObservableMacro.swift in Sources */,
+				88E54A5229B5475400252D99 /* MetaEnumMacro.swift in Sources */,
 				BD2CDEE9298B24040015A701 /* Diagnostics.swift in Sources */,
 				1D682A96299E3313006F9F78 /* CustomCodable.swift in Sources */,
 				BD2CDEED298B4A650015A701 /* DictionaryIndirectionMacro.swift in Sources */,
@@ -417,6 +424,7 @@
 			files = (
 				BDFB14B52948484000708DA6 /* MacroExamplesPluginTest.swift in Sources */,
 				3175781F298DBFA100D79290 /* NewTypePluginTests.swift in Sources */,
+				88E54A5429B5520A00252D99 /* MetaEnumMacroTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/MacroExamples/main.swift
+++ b/MacroExamples/main.swift
@@ -180,3 +180,15 @@ struct ShippingOptions {
   static let express: ShippingOptions = [.nextDay, .secondDay]
   static let all: ShippingOptions = [.express, .priority, .standard]
 }
+
+
+// `@MetaEnum` adds a nested enum called `Meta` with the same cases, but no
+// associated values/payloads. Handy for e.g. describing a schema.
+@MetaEnum enum Value {
+  case integer(Int)
+  case text(String)
+  case boolean(Bool)
+  case null
+}
+
+print(Value.Meta(.integer(42)) == .integer)

--- a/MacroExamplesLib/Macros.swift
+++ b/MacroExamplesLib/Macros.swift
@@ -100,6 +100,8 @@ public macro addAsync() =
 @attached(member)
 public macro CaseDetection() = #externalMacro(module: "MacroExamplesPlugin", type: "CaseDetectionMacro")
 
+@attached(member)
+public macro MetaEnum() = #externalMacro(module: "MacroExamplesPlugin", type: "MetaEnumMacro")
 
 @attached(member)
 public macro CodableKey(name: String) = #externalMacro(module: "MacroExamplesPlugin", type: "CodableKey")

--- a/MacroExamplesPlugin/MetaEnumMacro.swift
+++ b/MacroExamplesPlugin/MetaEnumMacro.swift
@@ -1,0 +1,141 @@
+import SwiftDiagnostics
+import SwiftSyntax
+import SwiftSyntaxMacros
+import SwiftSyntaxBuilder
+
+public struct MetaEnumMacro {
+  let parentTypeName: TokenSyntax
+  let childCases: [EnumCaseElementSyntax]
+  let access: ModifierListSyntax.Element?
+  let parentParamName: TokenSyntax
+
+  init(node: AttributeSyntax, declaration: some DeclGroupSyntax, context: some MacroExpansionContext) throws {
+    guard let enumDecl = declaration.as(EnumDeclSyntax.self) else {
+      throw DiagnosticsError(diagnostics: [
+        CaseMacroDiagnostic.notAnEnum(declaration).diagnose(at: Syntax(node))
+      ])
+    }
+
+    parentTypeName = enumDecl.identifier.with(\.trailingTrivia, [])
+
+    access = enumDecl.modifiers?.first(where: \.isNeededAccessLevelModifier)
+
+    childCases = enumDecl.caseElements.map { parentCase in
+      parentCase.with(\.associatedValue, nil)
+    }
+
+    parentParamName = context.createUniqueName("parent")
+  }
+
+  func makeMetaEnum() -> DeclSyntax {
+    // FIXME: Why does this need to be a string to make trailing trivia work properly?
+    let caseDecls = childCases.map { childCase in
+      "    case \(childCase.identifier)"
+    }.joined(separator: "\n")
+
+    return """
+
+        \(access)enum Meta {
+      \(raw: caseDecls)
+      \(makeMetaInit())
+        }
+
+      """
+  }
+
+  func makeMetaInit() -> DeclSyntax {
+    // FIXME: Why does this need to be a string to make trailing trivia work properly?
+    let caseStatements = childCases.map { childCase in
+      """
+            case .\(childCase.identifier):
+              self = .\(childCase.identifier)
+      """
+    }.joined(separator: "\n")
+
+    return """
+
+          \(access)init(_ \(parentParamName): \(parentTypeName)) {
+            switch \(parentParamName) {
+      \(raw: caseStatements)
+            }
+          }
+      """
+  }
+}
+
+extension MetaEnumMacro: MemberMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    providingMembersOf declaration: some DeclGroupSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    let macro = try MetaEnumMacro(node: node, declaration: declaration, context: context)
+
+    return [ macro.makeMetaEnum() ]
+  }
+}
+
+extension EnumDeclSyntax {
+  var caseElements: [EnumCaseElementSyntax] {
+    members.members.flatMap { member in
+      guard let caseDecl = member.decl.as(EnumCaseDeclSyntax.self) else {
+        return Array<EnumCaseElementSyntax>()
+      }
+
+      return Array(caseDecl.elements)
+    }
+  }
+}
+
+enum CaseMacroDiagnostic {
+  case notAnEnum(DeclGroupSyntax)
+}
+
+extension CaseMacroDiagnostic: DiagnosticMessage {
+  var message: String {
+    switch self {
+    case .notAnEnum(let decl):
+      return "'@MetaEnum' can only be attached to an enum, not \(decl.descriptiveDeclKind(withArticle: true))"
+    }
+  }
+
+  var diagnosticID: MessageID {
+    switch self {
+    case .notAnEnum:
+      return MessageID(domain: "MetaEnumDiagnostic", id: "notAnEnum")
+    }
+  }
+
+  var severity: DiagnosticSeverity {
+    switch self {
+    case .notAnEnum:
+      return .error
+    }
+  }
+
+  func diagnose(at node: Syntax) -> Diagnostic {
+    Diagnostic(node: node, message: self)
+  }
+}
+
+extension DeclGroupSyntax {
+  func descriptiveDeclKind(withArticle article: Bool = false) -> String {
+    switch self {
+    case is ActorDeclSyntax:
+      return article ? "an actor" : "actor"
+    case is ClassDeclSyntax:
+      return article ? "a class" : "class"
+    case is ExtensionDeclSyntax:
+      return article ? "an extension" : "extension"
+    case is ProtocolDeclSyntax:
+      return article ? "a protocol" : "protocol"
+    case is StructDeclSyntax:
+      return article ? "a struct" : "struct"
+    case is EnumDeclSyntax:
+      return article ? "an enum" : "enum"
+    default:
+      fatalError("Unknown DeclGroupSyntax")
+    }
+  }
+}
+

--- a/MacroExamplesPluginTest/MetaEnumMacroTests.swift
+++ b/MacroExamplesPluginTest/MetaEnumMacroTests.swift
@@ -1,0 +1,122 @@
+import XCTest
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+import MacroExamplesPlugin
+
+final class CaseMacroTests: XCTestCase {
+  let testMacros: [String: Macro.Type] = [
+    "MetaEnum": MetaEnumMacro.self
+  ]
+
+  func testBasic() throws {
+    let sf: SourceFileSyntax = """
+      @MetaEnum enum Cell {
+        case integer(Int)
+        case text(String)
+        case boolean(Bool)
+        case null
+      }
+      """
+
+    let context = BasicMacroExpansionContext(
+      sourceFiles: [sf: .init(moduleName: "MyModule", fullFilePath: "test.swift")]
+    )
+
+    let transformed = sf.expand(macros: testMacros, in: context)
+    XCTAssertEqual(transformed.description, """
+        enum Cell {
+          case integer(Int)
+          case text(String)
+          case boolean(Bool)
+          case null
+          enum Meta {
+            case integer
+            case text
+            case boolean
+            case null
+
+            init(_ __macro_local_6parentfMu_: Cell) {
+              switch __macro_local_6parentfMu_ {
+              case .integer:
+                self = .integer
+              case .text:
+                self = .text
+              case .boolean:
+                self = .boolean
+              case .null:
+                self = .null
+              }
+            }
+          }
+        }
+        """)
+  }
+
+  func testPublic() throws {
+    let sf: SourceFileSyntax = """
+      @MetaEnum public enum Cell {
+        case integer(Int)
+        case text(String)
+        case boolean(Bool)
+      }
+      """
+
+    let context = BasicMacroExpansionContext(
+      sourceFiles: [sf: .init(moduleName: "MyModule", fullFilePath: "test.swift")]
+    )
+
+    let transformed = sf.expand(macros: testMacros, in: context)
+    XCTAssertEqual(transformed.description, """
+        public enum Cell {
+          case integer(Int)
+          case text(String)
+          case boolean(Bool)
+          public enum Meta {
+            case integer
+            case text
+            case boolean
+
+            public init(_ __macro_local_6parentfMu_: Cell) {
+              switch __macro_local_6parentfMu_ {
+              case .integer:
+                self = .integer
+              case .text:
+                self = .text
+              case .boolean:
+                self = .boolean
+              }
+            }
+          }
+        }
+        """)
+  }
+
+  func testNonEnum() throws {
+    let sf: SourceFileSyntax = """
+      @MetaEnum struct Cell {
+        let integer: Int
+        let text: String
+        let boolean: Bool
+      }
+      """
+
+    let context = BasicMacroExpansionContext(
+      sourceFiles: [sf: .init(moduleName: "MyModule", fullFilePath: "test.swift")]
+    )
+
+    let transformed = sf.expand(macros: testMacros, in: context)
+    XCTAssertEqual(transformed.description, """
+      struct Cell {
+        let integer: Int
+        let text: String
+        let boolean: Bool
+      }
+      """)
+
+    XCTAssertEqual(context.diagnostics.count, 1)
+    let diag = try XCTUnwrap(context.diagnostics.first)
+    XCTAssertEqual(diag.message, "'@MetaEnum' can only be attached to an enum, not a struct")
+    XCTAssertEqual(diag.diagMessage.severity, .error)
+  }
+}


### PR DESCRIPTION
`@MetaEnum` adds a nested enum called `Meta` with the same cases, but no associated values/payloads. Handy for e.g. describing a schema.

```swift
@MetaEnum enum Cell {
  case integer(Int)
  case text(String)
  case boolean(Bool)
  case null

  // Synthesizes this:
  enum Meta {
    case integer
    case text
    case boolean
    case null

    init(_ __macro_local_6parentfMu_: Cell) {
      switch __macro_local_6parentfMu_ {
      case .integer:
        self = .integer
      case .text:
        self = .text
      case .boolean:
        self = .boolean
      case .null:
        self = .null
      }
    }
  }
}
```
I can see a few ways to customize this that might be useful: changing the name of the nested type, adding a raw type or (derivable) conformance to it, etc. I haven't thought about how to best design that, though.