### PR TITLE
@OptionSet macro: Choose Your Own Adventure edition

### DIFF
--- a/MacroExamples.xcodeproj/project.pbxproj
+++ b/MacroExamples.xcodeproj/project.pbxproj
@@ -26,7 +26,8 @@
 		BD841F82294CE1F600DA4D81 /* AddBlocker.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD841F81294CE1F600DA4D81 /* AddBlocker.swift */; };
 		BD8A3130294947BD00E83EB9 /* Macros.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD8A312F294947BD00E83EB9 /* Macros.swift */; };
 		BD8A31312949480600E83EB9 /* libMacroExamplesLib.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = BD8A3126294947A100E83EB9 /* libMacroExamplesLib.dylib */; };
-		BDC559D629B857DF00F26DFF /* OptionSetItemMacro.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDC559D529B857DF00F26DFF /* OptionSetItemMacro.swift */; };
+		BDB8C31129C26857000B4E7E /* OptionSetMacros.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDB8C31029C26857000B4E7E /* OptionSetMacros.swift */; };
+		BDC559D629B857DF00F26DFF /* BitfieldMacro.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDC559D529B857DF00F26DFF /* BitfieldMacro.swift */; };
 		BDF5AFE42947E5B000FA119B /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDF5AFE32947E5B000FA119B /* main.swift */; };
 		BDF5AFF82947E95C00FA119B /* StringifyMacro.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDF5AFF72947E95C00FA119B /* StringifyMacro.swift */; };
 		BDFB14B52948484000708DA6 /* MacroExamplesPluginTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDFB14B42948484000708DA6 /* MacroExamplesPluginTest.swift */; };
@@ -98,7 +99,8 @@
 		BD841F81294CE1F600DA4D81 /* AddBlocker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddBlocker.swift; sourceTree = "<group>"; };
 		BD8A3126294947A100E83EB9 /* libMacroExamplesLib.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = libMacroExamplesLib.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
 		BD8A312F294947BD00E83EB9 /* Macros.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Macros.swift; sourceTree = "<group>"; };
-		BDC559D529B857DF00F26DFF /* OptionSetItemMacro.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptionSetItemMacro.swift; sourceTree = "<group>"; };
+		BDB8C31029C26857000B4E7E /* OptionSetMacros.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptionSetMacros.swift; sourceTree = "<group>"; };
+		BDC559D529B857DF00F26DFF /* BitfieldMacro.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BitfieldMacro.swift; sourceTree = "<group>"; };
 		BDF5AFE02947E5B000FA119B /* MacroExamples */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = MacroExamples; sourceTree = BUILT_PRODUCTS_DIR; };
 		BDF5AFE32947E5B000FA119B /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		BDF5AFEE2947E61100FA119B /* libMacroExamplesPlugin.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = libMacroExamplesPlugin.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -161,7 +163,7 @@
 				1D682A95299E3313006F9F78 /* CustomCodable.swift */,
 				BD48319229AFF87200F3123A /* OptionSetMacro.swift */,
 				88E54A5129B5475400252D99 /* MetaEnumMacro.swift */,
-				BDC559D529B857DF00F26DFF /* OptionSetItemMacro.swift */,
+				BDC559D529B857DF00F26DFF /* BitfieldMacro.swift */,
 			);
 			path = MacroExamplesPlugin;
 			sourceTree = "<group>";
@@ -170,6 +172,7 @@
 			isa = PBXGroup;
 			children = (
 				BD8A312F294947BD00E83EB9 /* Macros.swift */,
+				BDB8C31029C26857000B4E7E /* OptionSetMacros.swift */,
 				31757820298DC4AF00D79290 /* NewType.swift */,
 			);
 			path = MacroExamplesLib;
@@ -385,6 +388,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BDB8C31129C26857000B4E7E /* OptionSetMacros.swift in Sources */,
 				BD8A3130294947BD00E83EB9 /* Macros.swift in Sources */,
 				31757821298DC4AF00D79290 /* NewType.swift in Sources */,
 			);
@@ -407,7 +411,7 @@
 				1D682A94299E2FFB006F9F78 /* CodableKey.swift in Sources */,
 				371A6719299C241F00E74A8A /* CaseDetectionMacro.swift in Sources */,
 				BD752BE5294D3BEC00D00A2E /* WarningMacro.swift in Sources */,
-				BDC559D629B857DF00F26DFF /* OptionSetItemMacro.swift in Sources */,
+				BDC559D629B857DF00F26DFF /* BitfieldMacro.swift in Sources */,
 				3175781D298DBC8700D79290 /* NewTypeMacro.swift in Sources */,
 				BDF5AFF82947E95C00FA119B /* StringifyMacro.swift in Sources */,
 				EC21BDEB298D9F9900D585C6 /* ObservableMacro.swift in Sources */,

--- a/MacroExamples.xcodeproj/project.pbxproj
+++ b/MacroExamples.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		BD841F82294CE1F600DA4D81 /* AddBlocker.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD841F81294CE1F600DA4D81 /* AddBlocker.swift */; };
 		BD8A3130294947BD00E83EB9 /* Macros.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD8A312F294947BD00E83EB9 /* Macros.swift */; };
 		BD8A31312949480600E83EB9 /* libMacroExamplesLib.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = BD8A3126294947A100E83EB9 /* libMacroExamplesLib.dylib */; };
+		BDC559D629B857DF00F26DFF /* OptionSetItemMacro.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDC559D529B857DF00F26DFF /* OptionSetItemMacro.swift */; };
 		BDF5AFE42947E5B000FA119B /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDF5AFE32947E5B000FA119B /* main.swift */; };
 		BDF5AFF82947E95C00FA119B /* StringifyMacro.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDF5AFF72947E95C00FA119B /* StringifyMacro.swift */; };
 		BDFB14B52948484000708DA6 /* MacroExamplesPluginTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDFB14B42948484000708DA6 /* MacroExamplesPluginTest.swift */; };
@@ -97,6 +98,7 @@
 		BD841F81294CE1F600DA4D81 /* AddBlocker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddBlocker.swift; sourceTree = "<group>"; };
 		BD8A3126294947A100E83EB9 /* libMacroExamplesLib.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = libMacroExamplesLib.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
 		BD8A312F294947BD00E83EB9 /* Macros.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Macros.swift; sourceTree = "<group>"; };
+		BDC559D529B857DF00F26DFF /* OptionSetItemMacro.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptionSetItemMacro.swift; sourceTree = "<group>"; };
 		BDF5AFE02947E5B000FA119B /* MacroExamples */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = MacroExamples; sourceTree = BUILT_PRODUCTS_DIR; };
 		BDF5AFE32947E5B000FA119B /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		BDF5AFEE2947E61100FA119B /* libMacroExamplesPlugin.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = libMacroExamplesPlugin.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -159,6 +161,7 @@
 				1D682A95299E3313006F9F78 /* CustomCodable.swift */,
 				BD48319229AFF87200F3123A /* OptionSetMacro.swift */,
 				88E54A5129B5475400252D99 /* MetaEnumMacro.swift */,
+				BDC559D529B857DF00F26DFF /* OptionSetItemMacro.swift */,
 			);
 			path = MacroExamplesPlugin;
 			sourceTree = "<group>";
@@ -404,6 +407,7 @@
 				1D682A94299E2FFB006F9F78 /* CodableKey.swift in Sources */,
 				371A6719299C241F00E74A8A /* CaseDetectionMacro.swift in Sources */,
 				BD752BE5294D3BEC00D00A2E /* WarningMacro.swift in Sources */,
+				BDC559D629B857DF00F26DFF /* OptionSetItemMacro.swift in Sources */,
 				3175781D298DBC8700D79290 /* NewTypeMacro.swift in Sources */,
 				BDF5AFF82947E95C00FA119B /* StringifyMacro.swift in Sources */,
 				EC21BDEB298D9F9900D585C6 /* ObservableMacro.swift in Sources */,
@@ -611,7 +615,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				OTHER_SWIFT_FLAGS = "-Xfrontend -enable-experimental-feature -Xfrontend Macros -Xfrontend -load-plugin-library -Xfrontend ${BUILD_DIR}/${CONFIGURATION}/libMacroExamplesPlugin.dylib -Xfrontend -dump-macro-expansions";
+				OTHER_SWIFT_FLAGS = "-Xfrontend -load-plugin-library -Xfrontend ${BUILD_DIR}/${CONFIGURATION}/libMacroExamplesPlugin.dylib -diagnostic-style swift";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				"SWIFT_OPTIMIZATION_LEVEL[arch=*]" = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -622,7 +626,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				OTHER_SWIFT_FLAGS = "-Xfrontend -enable-experimental-feature -Xfrontend Macros -Xfrontend -load-plugin-library -Xfrontend ${BUILD_DIR}/${CONFIGURATION}/libMacroExamplesPlugin.dylib -Xfrontend -dump-macro-expansions";
+				OTHER_SWIFT_FLAGS = "-Xfrontend -load-plugin-library -Xfrontend ${BUILD_DIR}/${CONFIGURATION}/libMacroExamplesPlugin.dylib -diagnostic-style swift";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 			};

--- a/MacroExamples/main.swift
+++ b/MacroExamples/main.swift
@@ -178,6 +178,30 @@ struct ShippingOptions {
   static let all: ShippingOptions = [.express, .priority, .standard]
 }
 
+@MyOptionSet<UInt8>
+struct ShippingOptionsNestedOptionsEnum {
+  private enum Options: UInt8 {
+    case nextDay, secondDay
+    case priority, standard
+  }
+
+  static let express: ShippingOptionsNestedOptionsEnum = [.nextDay, .secondDay]
+  static let all: ShippingOptionsNestedOptionsEnum = [.express, .priority, .standard]
+}
+
+@MyOptionSet<UInt8>
+enum ShippingOptionsNestedOptionSet {
+  case nextDay, secondDay
+  case priority, standard
+}
+
+#if false
+// FIXME: Currently triggers a compilation error
+extension ShippingOptionsNestedOptionSet.Set {
+  static let express: Self = [.nextDay, .secondDay]
+  static let all: Self = [.express, .priority, .standard]
+}
+#endif
 
 // `@MetaEnum` adds a nested enum called `Meta` with the same cases, but no
 // associated values/payloads. Handy for e.g. describing a schema.

--- a/MacroExamples/main.swift
+++ b/MacroExamples/main.swift
@@ -167,15 +167,12 @@ let jsonDecoder = JSONDecoder()
 let product = try jsonDecoder.decode(CustomCodableString.self, from: json)
 print(product.propertyWithOtherName)
 
-
 @MyOptionSet<UInt8>
 struct ShippingOptions {
-  private enum Options: Int {
-    case nextDay
-    case secondDay
-    case priority
-    case standard
-  }
+  static var nextDay: ShippingOptions
+  static var secondDay: ShippingOptions
+  static var priority: ShippingOptions
+  static var standard: ShippingOptions
 
   static let express: ShippingOptions = [.nextDay, .secondDay]
   static let all: ShippingOptions = [.express, .priority, .standard]

--- a/MacroExamplesLib/Macros.swift
+++ b/MacroExamplesLib/Macros.swift
@@ -107,37 +107,3 @@ public macro CodableKey(name: String) = #externalMacro(module: "MacroExamplesPlu
 
 @attached(member, names: arbitrary)
 public macro CustomCodable() = #externalMacro(module: "MacroExamplesPlugin", type: "CustomCodable")
-
-/// Create an option set from a struct that contains a nested `Options` enum.
-///
-/// Attach this macro to a struct that contains a nested `Options` enum
-/// with an integer raw value. The struct will be transformed to conform to
-/// `OptionSet` by
-///   1. Introducing a `rawValue` stored property to track which options are set,
-///    along with the necessary `RawType` typealias and initializers to satisfy
-///    the `OptionSet` protocol. The raw type is specified after `@OptionSet`,
-///    e.g., `@OptionSet<UInt8>`.
-///   2. Introducing static properties for each of the cases within the `Options`
-///    enum, of the type of the struct.
-///
-/// The `Options` enum must have a raw value, where its case elements
-/// each indicate a different option in the resulting option set. For example,
-/// the struct and its nested `Options` enum could look like this:
-///
-///     @MyOptionSet<UInt8>
-///     struct ShippingOptions {
-///       private enum Options: Int {
-///         case nextDay
-///         case secondDay
-///         case priority
-///         case standard
-///       }
-///     }
-@attached(member, names: named(RawValue), named(rawValue), named(`init`))
-@attached(conformance)
-@attached(memberAttribute)
-public macro MyOptionSet<RawType>() = #externalMacro(module: "MacroExamplesPlugin", type: "OptionSetMacro")
-
-
-@attached(accessor)
-public macro OptionSetItem(bit: Int) = #externalMacro(module: "MacroExamplesPlugin", type: "OptionSetItemMacro")

--- a/MacroExamplesLib/Macros.swift
+++ b/MacroExamplesLib/Macros.swift
@@ -83,7 +83,6 @@ public struct ObservationRegistrar<Subject: Observable> {
 }
 
 @attached(member, names: named(Storage), named(_storage), named(_registrar), named(addObserver), named(removeObserver), named(withTransaction))
-@attached(memberAttribute)
 public macro Observable() = #externalMacro(module: "MacroExamplesPlugin", type: "ObservableMacro")
 
 @attached(accessor)
@@ -106,7 +105,7 @@ public macro MetaEnum() = #externalMacro(module: "MacroExamplesPlugin", type: "M
 @attached(member)
 public macro CodableKey(name: String) = #externalMacro(module: "MacroExamplesPlugin", type: "CodableKey")
 
-@attached(member, names: named(CodingKeys))
+@attached(member, names: arbitrary)
 public macro CustomCodable() = #externalMacro(module: "MacroExamplesPlugin", type: "CustomCodable")
 
 /// Create an option set from a struct that contains a nested `Options` enum.
@@ -116,7 +115,8 @@ public macro CustomCodable() = #externalMacro(module: "MacroExamplesPlugin", typ
 /// `OptionSet` by
 ///   1. Introducing a `rawValue` stored property to track which options are set,
 ///    along with the necessary `RawType` typealias and initializers to satisfy
-///    the `OptionSet` protocol.
+///    the `OptionSet` protocol. The raw type is specified after `@OptionSet`,
+///    e.g., `@OptionSet<UInt8>`.
 ///   2. Introducing static properties for each of the cases within the `Options`
 ///    enum, of the type of the struct.
 ///
@@ -124,7 +124,7 @@ public macro CustomCodable() = #externalMacro(module: "MacroExamplesPlugin", typ
 /// each indicate a different option in the resulting option set. For example,
 /// the struct and its nested `Options` enum could look like this:
 ///
-///     @MyOptionSet
+///     @MyOptionSet<UInt8>
 ///     struct ShippingOptions {
 ///       private enum Options: Int {
 ///         case nextDay
@@ -133,6 +133,11 @@ public macro CustomCodable() = #externalMacro(module: "MacroExamplesPlugin", typ
 ///         case standard
 ///       }
 ///     }
-@attached(member, names: arbitrary)
+@attached(member, names: named(RawValue), named(rawValue), named(`init`))
 @attached(conformance)
+@attached(memberAttribute)
 public macro MyOptionSet<RawType>() = #externalMacro(module: "MacroExamplesPlugin", type: "OptionSetMacro")
+
+
+@attached(accessor)
+public macro OptionSetItem(bit: Int) = #externalMacro(module: "MacroExamplesPlugin", type: "OptionSetItemMacro")

--- a/MacroExamplesLib/OptionSetMacros.swift
+++ b/MacroExamplesLib/OptionSetMacros.swift
@@ -1,0 +1,96 @@
+/// Specifies the form of option set to which the option set macro is applied.
+public enum OptionSetForm {
+  /// Options are described via static variables within the struct, allow
+  /// of which are expected to have the same type as `Self`.
+  /// the option set macros.
+  ///
+  ///     @OptionSet<UInt8>
+  ///     struct ShippingOptions {
+  ///       static var nextDay: ShippingOptions
+  ///       static var secondDay: ShippingOptions
+  ///       static var priority: ShippingOptions
+  ///       static var standard: ShippingOptions
+  ///     }
+  ///
+  ///  Any static variable that has an initializer already will be ignored.
+  case staticVariables
+
+  /// Options are described via the cases of a nested enum with the given
+  /// name.
+  ///
+  ///     @OptionSet<UInt8>
+  ///     struct ShippingOptions {
+  ///       private enum Options {
+  ///         case nextDay
+  ///         case secondDay
+  ///         case priority
+  ///         case standard
+  ///       }
+  ///     }
+  ///
+  ///  The cases will be used to indicate bit positions in the resulting
+  ///  raw value, and the `OptionSet` macro will introduced static variables
+  ///  of the type of the struct itself (similar to those that have are
+  ///  written explicitly for the `staticVariables` form).
+  case nestedOptionsEnum(String = "Options")
+
+  /// Options are described via cases on the enum to which the option set
+  /// macro is applied.
+  ///
+  ///     @OptionSet<UInt8>
+  ///     enum ShippingOptions {
+  ///       case nextDay
+  ///       case secondDay
+  ///       case priority
+  ///       case standard
+  ///     }
+  ///
+  /// As with `nestedEnum`, the cases provide the bit numbers for the
+  /// corresponding options in the raw value. With this kind, a nested
+  /// struct with the given name will be created that is itself an option
+  /// set, e.g.,
+  ///
+  ///     struct Set: OptionSet {
+  ///       var rawValue: UInt8
+  ///       static var nextDay: Set = Set(rawValue: 1 << 0)
+  ///       static var secondDay: Set = Set(rawValue: 1 << 1)
+  ///       static var priority: Set = Set(rawValue: 1 << 2)
+  ///       static var standard: Set = Set(rawValue: 1 << 3)
+  ///     }
+  case nestedOptionSet(String = "Set")
+}
+
+/// Create an bit-packed option set from a type that sketches the option names.
+///
+/// TODO: Update this
+///
+/// Attach this macro to a struct that contains a nested `Options` enum
+/// with an integer raw value. The struct will be transformed to conform to
+/// `OptionSet` by
+///   1. Introducing a `rawValue` stored property to track which options are set,
+///    along with the necessary `RawType` typealias and initializers to satisfy
+///    the `OptionSet` protocol. The raw type is specified after `@OptionSet`,
+///    e.g., `@OptionSet<UInt8>`.
+///   2. Introducing static properties for each of the cases within the `Options`
+///    enum, of the type of the struct.
+///
+/// The `Options` enum must have a raw value, where its case elements
+/// each indicate a different option in the resulting option set. For example,
+/// the struct and its nested `Options` enum could look like this:
+///
+///     @MyOptionSet<UInt8>
+///     struct ShippingOptions {
+///       private enum Options: Int {
+///         case nextDay
+///         case secondDay
+///         case priority
+///         case standard
+///       }
+///     }
+@attached(member, names: named(RawValue), named(rawValue), named(`init`), arbitrary)
+@attached(conformance)
+@attached(memberAttribute)
+public macro MyOptionSet<RawType>() = #externalMacro(module: "MacroExamplesPlugin", type: "OptionSetMacro")
+
+@attached(accessor)
+public macro Bitfield(bit: Int) = #externalMacro(module: "MacroExamplesPlugin", type: "BitfieldMacro")

--- a/MacroExamplesPlugin/BitfieldMacro.swift
+++ b/MacroExamplesPlugin/BitfieldMacro.swift
@@ -2,9 +2,9 @@ import SwiftSyntax
 import SwiftSyntaxBuilder
 import SwiftSyntaxMacros
 
-public struct OptionSetItemMacro { }
+public struct BitfieldMacro { }
 
-extension OptionSetItemMacro: AccessorMacro {
+extension BitfieldMacro: AccessorMacro {
   public static func expansion(
     of attribute: AttributeSyntax,
     providingAccessorsOf declaration: some DeclSyntaxProtocol,

--- a/MacroExamplesPlugin/OptionSetItemMacro.swift
+++ b/MacroExamplesPlugin/OptionSetItemMacro.swift
@@ -1,0 +1,28 @@
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+
+public struct OptionSetItemMacro { }
+
+extension OptionSetItemMacro: AccessorMacro {
+  public static func expansion(
+    of attribute: AttributeSyntax,
+    providingAccessorsOf declaration: some DeclSyntaxProtocol,
+    in context: some MacroExpansionContext
+  ) throws -> [AccessorDeclSyntax] {
+    guard case let .argumentList(arguments) = attribute.argument,
+        let bitArg = arguments.first(labeled: "bit"),
+        let bit = bitArg.expression.as(IntegerLiteralExprSyntax.self)?.digits else {
+      return []
+    }
+
+    return [
+      """
+      
+        get {
+          Self(rawValue: 1 << \(bit))
+        }
+      """
+    ]
+  }
+}

--- a/MacroExamplesPlugin/OptionSetMacro.swift
+++ b/MacroExamplesPlugin/OptionSetMacro.swift
@@ -55,22 +55,135 @@ extension TupleExprElementListSyntax {
   }
 }
 
+// Mirrored from the library because I'm too lazy to factor it out right now
+private enum OptionSetForm: Equatable {
+  case staticVariables
+  case nestedOptionsEnum(String = "Options")
+  case nestedOptionSet(String = "Set")
+}
+
 public struct OptionSetMacro {
+  /// Decode a "form:" argument to the option set macro, if present.
+  private static func decodeOptionSetFormArgument(
+    of attribute: AttributeSyntax,
+    in context: some MacroExpansionContext
+  ) -> OptionSetForm? {
+    // Dig out the "form" argument, if there is one.
+    guard case let .argumentList(arguments) = attribute.argument,
+          let formArgument = arguments.first(labeled: "form")?.expression else {
+      // No argument, this is fine.
+      return nil
+    }
+
+    // If it was explicitly `nil`, then we've been asked to infer the form from
+    // the structure.
+    if formArgument.is(NilLiteralExprSyntax.self) {
+      return nil
+    }
+
+    // If there is a call (e.g., for .nestedOptionsEnum("Flags")), dig out
+    // the argument string ("Flags") and look through the call.
+    let enumElement: ExprSyntax
+    let callArgument: String?
+    if let call = formArgument.as(FunctionCallExprSyntax.self) {
+      if call.argumentList.isEmpty {
+        callArgument = nil
+      } else if call.argumentList.count == 1,
+                let firstArg = call.argumentList.first,
+                let stringLiteral = firstArg.expression.as(StringLiteralExprSyntax.self),
+                stringLiteral.segments.count == 1,
+                case let .stringSegment(stringArgument)? = stringLiteral.segments.first {
+        callArgument = stringArgument.content.text
+      } else {
+        // FIXME: Diagnose extra/wrong arguments.
+        return nil
+      }
+
+      enumElement = call.calledExpression
+    } else {
+      callArgument = nil
+      enumElement = formArgument
+    }
+
+    // Make sure we have `.<something>` or `OptionSetForm.<something>`.
+    guard let memberAccess = enumElement.as(MemberAccessExprSyntax.self),
+          memberAccess.base == nil ||
+            memberAccess.base?.trimmedDescription == "OptionSetForm"
+    else {
+      // FIXME: Produce an error; we don't recognize the argument.
+      return nil
+    }
+
+    switch memberAccess.name.text {
+    case "staticVariables":
+      return .staticVariables
+
+    case "nestedOptionsEnum":
+      return .nestedOptionsEnum(callArgument ?? "Options")
+
+    case "nestedOptionSet":
+      return .nestedOptionSet(callArgument ?? "Set")
+
+    default:
+      // FIXME: Produce an error; we don't recognize the enum case.
+      return nil
+    }
+  }
+
+  /// Find a nested enum with the given name in the given declaration.
+  static func findNestedEnum(named: String, in decl: some DeclGroupSyntax) -> EnumDeclSyntax? {
+    return decl.members.members.lazy.compactMap { member in
+      if let enumDecl = member.decl.as(EnumDeclSyntax.self),
+         enumDecl.identifier.text == named {
+        return enumDecl
+      }
+
+      return nil
+    }.first
+  }
+
+  /// Infer the form of the option set from from declaration to which the
+  /// option set macro is attached.
+  private static func inferOptionSetForm(_ decl: some DeclGroupSyntax) -> OptionSetForm? {
+    // If the macro is attached to an enum, produce a nested option set struct.
+    if decl.is(EnumDeclSyntax.self) {
+      return .nestedOptionSet()
+    }
+
+    // If the macro is attached to something other than a struct, we can't
+    // infer anything.
+    guard let structDecl = decl.as(StructDeclSyntax.self) else {
+      return nil
+    }
+
+    // If there is a nested "Options" enum, use it.
+    if let _ = findNestedEnum(named: "Options", in: structDecl) {
+      return .nestedOptionsEnum()
+    }
+
+    // If there is at least one static variable that meets the criteria, we
+    // can update static variables.
+    for member in structDecl.members.members {
+      if let varDecl = member.decl.as(VariableDeclSyntax.self),
+         let _ = varDecl.getOptionSetItemCandidateName(structName: structDecl.identifier) {
+        return .staticVariables
+      }
+    }
+
+    // There isn't enough structure to infer the form of the option set.
+    return nil
+  }
+
   /// Decodes the arguments to the macro expansion.
   ///
   /// - Returns: the important arguments used by the various roles of this
   /// macro inhabits, or nil if an error occurred.
-  static func decodeExpansion(
+  fileprivate static func decodeExpansion(
     of attribute: AttributeSyntax,
     attachedTo decl: some DeclGroupSyntax,
     in context: some MacroExpansionContext
-  ) -> (StructDeclSyntax, TypeSyntax)? {
+  ) -> (TypeSyntax, OptionSetForm)? {
     // Only apply to structs.
-    guard let structDecl = decl.as(StructDeclSyntax.self) else {
-      context.diagnose(OptionSetMacroDiagnostic.requiresStruct.diagnose(at: decl))
-      return nil
-    }
-
     // Retrieve the raw type from the attribute.
     guard let genericArgs = attribute.attributeName.as(SimpleTypeIdentifierSyntax.self)?.genericArgumentClause,
           let rawType = genericArgs.arguments.first?.argumentType else {
@@ -78,8 +191,17 @@ public struct OptionSetMacro {
       return nil
     }
 
+    let form: OptionSetForm
+    if let specifiedForm = decodeOptionSetFormArgument(of: attribute, in: context) {
+      form = specifiedForm
+    } else if let inferredForm = inferOptionSetForm(decl) {
+      form = inferredForm
+    } else {
+      // FIXME: produce an error
+      return nil
+    }
 
-    return (structDecl, rawType)
+    return (rawType, form)
   }
 }
 
@@ -155,7 +277,13 @@ extension OptionSetMacro: MemberAttributeMacro {
     in context: some MacroExpansionContext
   ) throws -> [AttributeSyntax] {
     // Decode the expansion arguments.
-    guard let (structDecl, _) = decodeExpansion(of: attribute, attachedTo: declaration, in: context) else {
+    //
+    // The member-attribute expansion of the OptionSet macro only applies to the static-variables
+    // form of the option set, where the static variables already exist and need to be
+    // annotated with the appropriate `@Bitfield` attribute.
+    guard let (_, form) = decodeExpansion(of: attribute, attachedTo: declaration, in: context),
+          form == .staticVariables,
+          let structDecl = declaration.as(StructDeclSyntax.self) else {
       return []
     }
 
@@ -184,7 +312,7 @@ extension OptionSetMacro: MemberAttributeMacro {
       bit += 1
     }
 
-    // If we did not found our member in the list, fail. This could happen
+    // If we did not find our member in the list, fail. This could happen
     // if the item came from another macro expansion.
     if !found {
       context.diagnose(
@@ -192,7 +320,7 @@ extension OptionSetMacro: MemberAttributeMacro {
       return []
     }
 
-    return ["@OptionSetItem(bit: \(literal: bit))"]
+    return ["@Bitfield(bit: \(literal: bit))"]
   }
 }
 
@@ -203,8 +331,23 @@ extension OptionSetMacro: ConformanceMacro {
     in context: some MacroExpansionContext
   ) throws -> [(TypeSyntax, GenericWhereClauseSyntax?)] {
     // Decode the expansion arguments.
-    guard let (structDecl, _) = decodeExpansion(of: attribute, attachedTo: decl, in: context) else {
+    //
+    // The conformance expansion is only relevant to the nested-options-enum
+    // and static-variables forms, which add the conformance. In both cases,
+    // we are dealing with a struct.
+    guard let (_, form) = decodeExpansion(of: attribute, attachedTo: decl, in: context),
+          let structDecl = decl.as(StructDeclSyntax.self) else {
       return []
+    }
+
+    switch form {
+    case .nestedOptionSet:
+      // The nested option set form doesn't add any conformances; the conformance
+      // is on the inner type.
+      return []
+
+    case .nestedOptionsEnum, .staticVariables:
+      break
     }
 
     // If there is an explicit conformance to OptionSet already, don't add one.
@@ -217,25 +360,87 @@ extension OptionSetMacro: ConformanceMacro {
   }
 }
 
+extension EnumDeclSyntax {
+  /// Retrieve a flattened set of all of the case elements in the enum.
+  var allCaseElements: [EnumCaseElementSyntax] {
+    return members.members.flatMap { member in
+      guard let caseDecl = member.decl.as(EnumCaseDeclSyntax.self) else {
+        return Array<EnumCaseElementSyntax>()
+      }
+
+      return Array(caseDecl.elements)
+    }
+  }
+}
+
 extension OptionSetMacro: MemberMacro {
+  /// Create the set of static variables that provided the option values, using the
+  /// cases of the given enum as input.
+  private static func makeStaticVariables(
+    forCasesOf enumDecl: EnumDeclSyntax,
+    access: ModifierListSyntax.Element?
+  ) -> [DeclSyntax] {
+    let allCases = enumDecl.allCaseElements
+    return allCases.map { (element) -> DeclSyntax in
+      """
+      
+      \(access) static let \(element.identifier.trimmed): Self =
+        Self(rawValue: 1 << \(enumDecl.identifier.trimmed).\(element.identifier).rawValue)
+      """
+    }
+  }
+
   public static func expansion(
     of attribute: AttributeSyntax,
     providingMembersOf decl: some DeclGroupSyntax,
     in context: some MacroExpansionContext
   ) throws -> [DeclSyntax] {
     // Decode the expansion arguments.
-    guard let (_, rawType) = decodeExpansion(of: attribute, attachedTo: decl, in: context) else {
+    guard let (rawType, form) = decodeExpansion(of: attribute, attachedTo: decl, in: context) else {
       return []
     }
 
     // Dig out the access control keyword we need.
     let access = decl.modifiers?.first(where: \.isNeededAccessLevelModifier)
 
-    return [
-      "\(access)typealias RawValue = \(rawType)",
-      "\(access)var rawValue: RawValue",
-      "\(access)init() { self.rawValue = 0 }",
-      "\(access)init(rawValue: RawValue) { self.rawValue = rawValue }",
+    // Across all forms, the raw value members are the same.
+    // FIXME: We should filter out any of these that were already provided.
+    let rawValueMembers: [DeclSyntax] = [
+      "\n\(access)typealias RawValue = \(rawType)",
+      "\n\(access)var rawValue: RawValue",
+      "\n\(access)init() { self.rawValue = 0 }",
+      "\n\(access)init(rawValue: RawValue) { self.rawValue = rawValue }",
     ]
+
+    switch form {
+    case .staticVariables:
+      // When annotating static variables, we only need the raw-value members.
+      // Everything else has already been declared.
+      return rawValueMembers
+
+    case .nestedOptionsEnum(let optionsSetEnumName):
+      guard let optionSetEnum = findNestedEnum(named: optionsSetEnumName, in: decl) else {
+        // FIXME: Diagnose missing option enum
+        return rawValueMembers
+      }
+
+      return rawValueMembers + makeStaticVariables(forCasesOf: optionSetEnum, access: access)
+
+    case .nestedOptionSet(_):
+      guard let enumDecl = decl.as(EnumDeclSyntax.self) else {
+        // FIXME: Diagnose not-on-an-enum
+        return rawValueMembers
+      }
+
+      return [
+        """
+        
+        \(access)struct Set: OptionSet {\(raw: (rawValueMembers + makeStaticVariables(forCasesOf: enumDecl, access: access)).map {
+            $0.description
+          }.joined(separator: ""))
+        }
+        """
+      ]
+    }
   }
 }

--- a/MacroExamplesPluginTest/MacroExamplesPluginTest.swift
+++ b/MacroExamplesPluginTest/MacroExamplesPluginTest.swift
@@ -6,6 +6,8 @@ import XCTest
 
 var testMacros: [String: Macro.Type] = [
   "stringify" : StringifyMacro.self,
+  "OptionSet" : OptionSetMacro.self,
+  "OptionSetItem" : OptionSetItemMacro.self,
 ]
 
 final class MacroExamplesPluginTests: XCTestCase {
@@ -26,5 +28,59 @@ final class MacroExamplesPluginTests: XCTestCase {
       let b = ("Hello, \(name)", #""Hello, \(name)""#)
       """#
     )
+  }
+
+  func testOptionSet() {
+    let sf: SourceFileSyntax =
+      """
+      @OptionSet<UInt8>
+      struct ShippingOptions {
+        static var nextDay: ShippingOptions
+        static var secondDay: ShippingOptions
+        static var priority: ShippingOptions
+        static var standard: ShippingOptions
+
+        static let express: ShippingOptions = [.nextDay, .secondDay]
+        static let all: ShippingOptions = [.express, .priority, .standard]
+
+      }
+      """
+    let context = BasicMacroExpansionContext.init(
+      sourceFiles: [sf: .init(moduleName: "MyModule", fullFilePath: "test.swift")]
+    )
+    let transformedSF = sf.expand(macros: testMacros, in: context)
+    XCTAssertEqual(
+      transformedSF.description,
+      #"""
+
+      struct ShippingOptions {
+        static var nextDay: ShippingOptions {
+        get {
+          Self(rawValue: 1 << 0)
+        }
+      }
+        static var secondDay: ShippingOptions {
+        get {
+          Self(rawValue: 1 << 1)
+        }
+      }
+        static var priority: ShippingOptions {
+        get {
+          Self(rawValue: 1 << 2)
+        }
+      }
+        static var standard: ShippingOptions {
+        get {
+          Self(rawValue: 1 << 3)
+        }
+      }
+
+        static let express: ShippingOptions = [.nextDay, .secondDay]
+        static let all: ShippingOptions = [.express, .priority, .standard]typealias RawValue = UInt8var rawValue: RawValueinit() { self.rawValue = 0 }init(rawValue: RawValue) { self.rawValue = rawValue }
+
+      }
+      """#
+    )
+
   }
 }

--- a/MacroExamplesPluginTest/NewTypePluginTests.swift
+++ b/MacroExamplesPluginTest/NewTypePluginTests.swift
@@ -17,15 +17,11 @@ final class NewTypePluginTests: XCTestCase {
       }
       """#
 
-    // print(sf.recursiveDescription)
-
     let context = BasicMacroExpansionContext(
       sourceFiles: [sf: .init(moduleName: "MyModule", fullFilePath: "test.swift")]
     )
 
     let transformed = sf.expand(macros: testMacros, in: context)
-
-    // print(transformed.recursiveDescription)
 
     XCTAssertEqual(
       transformed.description,


### PR DESCRIPTION
Make the `@OptionSet` macro simultaneously support *three* different forms of option set!

Form #1:

```swift
@OptionSet<UInt8>
struct ShippingOptions {
  static var nextDay: ShippingOptions
  static var secondDay: ShippingOptions
  static var priority: ShippingOptions
  static var standard: ShippingOptions
}
```

Form #2:

```swift
@OptionSet<UInt8>
struct ShippingOptions {
  enum Options {
    case nextDay
    case secondDay
    case priority
    case standard
  }
}
```

Form #3:

```swift
@OptionSet<UInt8>
enum Options: UInt8 {
  case nextDay
  case secondDay
  case priority
  case standard

  // macro adds a nested type Set that is the option set
}
```