### PR TITLE
Add URL macro to create valid non-optional URLs.

### DIFF
--- a/MacroExamples.xcodeproj/project.pbxproj
+++ b/MacroExamples.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		371A6719299C241F00E74A8A /* CaseDetectionMacro.swift in Sources */ = {isa = PBXBuildFile; fileRef = 371A6718299C241F00E74A8A /* CaseDetectionMacro.swift */; };
 		88E54A5229B5475400252D99 /* MetaEnumMacro.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88E54A5129B5475400252D99 /* MetaEnumMacro.swift */; };
 		88E54A5429B5520A00252D99 /* MetaEnumMacroTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88E54A5329B5520A00252D99 /* MetaEnumMacroTests.swift */; };
+		911F5F8829BB5A150081AF9C /* URLMacro.swift in Sources */ = {isa = PBXBuildFile; fileRef = 911F5F8729BB5A150081AF9C /* URLMacro.swift */; };
 		BD2CDEE9298B24040015A701 /* Diagnostics.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD2CDEE8298B24040015A701 /* Diagnostics.swift */; };
 		BD2CDEEB298B34730015A701 /* WrapStoredPropertiesMacro.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD2CDEEA298B34730015A701 /* WrapStoredPropertiesMacro.swift */; };
 		BD2CDEED298B4A650015A701 /* DictionaryIndirectionMacro.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD2CDEEC298B4A650015A701 /* DictionaryIndirectionMacro.swift */; };
@@ -86,6 +87,7 @@
 		371A6718299C241F00E74A8A /* CaseDetectionMacro.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaseDetectionMacro.swift; sourceTree = "<group>"; };
 		88E54A5129B5475400252D99 /* MetaEnumMacro.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetaEnumMacro.swift; sourceTree = "<group>"; };
 		88E54A5329B5520A00252D99 /* MetaEnumMacroTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetaEnumMacroTests.swift; sourceTree = "<group>"; };
+		911F5F8729BB5A150081AF9C /* URLMacro.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URLMacro.swift; sourceTree = "<group>"; };
 		BD2CDEE8298B24040015A701 /* Diagnostics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Diagnostics.swift; sourceTree = "<group>"; };
 		BD2CDEEA298B34730015A701 /* WrapStoredPropertiesMacro.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WrapStoredPropertiesMacro.swift; sourceTree = "<group>"; };
 		BD2CDEEC298B4A650015A701 /* DictionaryIndirectionMacro.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryIndirectionMacro.swift; sourceTree = "<group>"; };
@@ -143,6 +145,7 @@
 		BD841F80294CE14500DA4D81 /* MacroExamplesPlugin */ = {
 			isa = PBXGroup;
 			children = (
+				911F5F8729BB5A150081AF9C /* URLMacro.swift */,
 				BDF5AFF72947E95C00FA119B /* StringifyMacro.swift */,
 				BD841F81294CE1F600DA4D81 /* AddBlocker.swift */,
 				BD752BE4294D3BEC00D00A2E /* WarningMacro.swift */,
@@ -414,6 +417,7 @@
 				BD752BE7294D461B00D00A2E /* FontLiteralMacro.swift in Sources */,
 				BD7324B829989178009C6A08 /* AddCompletionHandlerMacro.swift in Sources */,
 				BD48319329AFF87200F3123A /* OptionSetMacro.swift in Sources */,
+				911F5F8829BB5A150081AF9C /* URLMacro.swift in Sources */,
 				1D682A92299CE4C6006F9F78 /* AddAsyncMacro.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/MacroExamples/main.swift
+++ b/MacroExamples/main.swift
@@ -26,6 +26,14 @@ struct Font: ExpressibleByFontLiteral {
 
 let _: Font = #fontLiteral(name: "Comic Sans", size: 14, weight: .thin)
 
+// "#URL" macro provides compile time checked URL construction. If the URL is
+// malformed an error is emitted. Otherwise a non-optional URL is expanded.
+print(#URL("https://swift.org/"))
+
+let domain = "domain.com"
+//print(#URL("https://\(domain)/api/path")) // error: #URL requires a static string literal
+//print(#URL("https://not a url.com")) // error: Malformed url
+
 // Use the "wrapStoredProperties" macro to deprecate all of the stored
 // properties.
 @wrapStoredProperties(#"available(*, deprecated, message: "hands off my data")"#)

--- a/MacroExamplesLib/Macros.swift
+++ b/MacroExamplesLib/Macros.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 /// "Stringify" the provided value and produce a tuple that includes both the
 /// original value as well as the source code that generated it.
 @freestanding(expression) public macro stringify<T>(_ value: T) -> (T, String) = #externalMacro(module: "MacroExamplesPlugin", type: "StringifyMacro")
@@ -25,6 +27,10 @@ public protocol ExpressibleByFontLiteral {
 /// Font literal similar to, e.g., #colorLiteral.
 @freestanding(expression) public macro fontLiteral<T>(name: String, size: Int, weight: FontWeight) -> T = #externalMacro(module: "MacroExamplesPlugin", type: "FontLiteralMacro")
   where T: ExpressibleByFontLiteral
+
+/// Check if provided string literal is a valid URL and produce a non-optional
+/// URL value. Emit error otherwise.
+@freestanding(expression) public macro URL(_ stringLiteral: String) -> URL = #externalMacro(module: "MacroExamplesPlugin", type: "URLMacro")
 
 
 /// Apply the specified attribute to each of the stored properties within the

--- a/MacroExamplesPlugin/URLMacro.swift
+++ b/MacroExamplesPlugin/URLMacro.swift
@@ -1,0 +1,27 @@
+import Foundation
+import SwiftSyntax
+import SwiftSyntaxMacros
+
+/// Creates a non-optional URL from a static string. The string is checked to
+/// be valid during compile time.
+public struct URLMacro: ExpressionMacro {
+  public static func expansion(
+    of node: some FreestandingMacroExpansionSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> ExprSyntax {
+
+    guard let argument = node.argumentList.first?.expression,
+          let segments = argument.as(StringLiteralExprSyntax.self)?.segments,
+          segments.count == 1,
+          case .stringSegment(let literalSegment)? = segments.first
+    else {
+      throw CustomError.message("#URL requires a static string literal")
+    }
+
+    guard let _ = URL(string: literalSegment.content.text) else {
+      throw CustomError.message("malformed url: \(argument)")
+    }
+
+    return "URL(string: \(argument))!"
+  }
+}

--- a/MacroExamplesPluginTest/MacroExamplesPluginTest.swift
+++ b/MacroExamplesPluginTest/MacroExamplesPluginTest.swift
@@ -27,4 +27,27 @@ final class MacroExamplesPluginTests: XCTestCase {
       """#
     )
   }
+
+  func testURL() throws {
+    let sf: SourceFileSyntax =
+        #"""
+        let invalid = #URL("not a url")
+        let valid = #URL("https://swift.org/")
+        """#
+    let context = BasicMacroExpansionContext.init(
+      sourceFiles: [sf: .init(moduleName: "MyModule", fullFilePath: "test.swift")]
+    )
+    let transformedSF = sf.expand(macros: ["URL" : URLMacro.self], in: context)
+    XCTAssertEqual(
+      transformedSF.description,
+        #"""
+        let invalid = #URL("not a url")
+        let valid = URL(string: "https://swift.org/")!
+        """#
+    )
+    XCTAssertEqual(context.diagnostics.count, 1)
+    let diagnostic = try XCTUnwrap(context.diagnostics.first)
+    XCTAssertEqual(diagnostic.message, #"malformed url: "not a url""#)
+    XCTAssertEqual(diagnostic.diagMessage.severity, .error)
+  }
 }


### PR DESCRIPTION
Add a #URL macro that provides compile time checked URL literals.

Motivation:

This is similar in spirit to compile time checked regular expressions. For a literal `Regex` the compiler makes sure that the regex has no syntactic errors by parsing it at compile time. In case of a syntax error the compiler emits an error (and does not produce any code).

When the regex parses without error a non-optional, non-throwing initializer is inserted. During runtime the Regex has to be parsed again to create the actual instance but it is known to not throw an error.

This behavior, where the compiler checks the validity of an initializer's arguments would be helpful for many other types, for example a `SemVer` type that checks for a valid semantic version.

In these cases macros seem like a good workaround (until we get statically checked arguments).