### PR TITLE
Add testTarget

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,14 @@
+{
+  "pins" : [
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-syntax.git",
+      "state" : {
+        "branch" : "main",
+        "revision" : "4d8981fa63789d105244a085394b35bc10d030c8"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/Package.swift
+++ b/Package.swift
@@ -38,6 +38,10 @@ let package = Package(
         ],
         path: "MacroExamplesPlugin"
       ),
+	  .testTarget(name: "MacroExamplesPluginTest",
+		dependencies: ["MacroExamplesPlugin"],
+		path: "MacroExamplesPluginTest"
+	  ),
       .target(name: "MacroExamplesLib",
         dependencies: ["MacroExamplesPlugin"],  
         path: "MacroExamplesLib"


### PR DESCRIPTION
Adds missing testTarget so we can run the unit tests in the test target.