### PR TITLE
Improve macro expansion style

### DIFF
--- a/MacroExamplesPlugin/CustomCodable.swift
+++ b/MacroExamplesPlugin/CustomCodable.swift
@@ -34,8 +34,7 @@ public struct CustomCodable: MemberMacro {
     
     let codingKeys: DeclSyntax = """
     
-      enum CodingKeys: String, CodingKey {
-        \(raw: cases.joined(separator: "\n"))
+      enum CodingKeys: String, CodingKey {\n\(raw: cases.joined(separator: "\n"))
       }
 
     """

--- a/MacroExamplesPlugin/ObservableMacro.swift
+++ b/MacroExamplesPlugin/ObservableMacro.swift
@@ -28,7 +28,7 @@ public struct ObservableMacro: MemberMacro, MemberAttributeMacro {
       return []
     }
 
-    let parentName = identified.identifier
+      let parentName = identified.identifier.trimmed
 
     let registrar: DeclSyntax =
       """


### PR DESCRIPTION
## Description
- Trimming identifier of `ObservableMacro`
- Fix an indetation of `CustomCodable`

### ObservableMacro
|||
| --- | --- |
| Before | <img width="675" alt="image" src="https://github.com/DougGregor/swift-macro-examples/assets/41236155/ad3a27f1-83f4-4903-b832-9a7e28357086">  |
| After | <img width="675" alt="스크린샷 2023-06-15 오전 9 03 08" src="https://github.com/DougGregor/swift-macro-examples/assets/41236155/f26e0e96-4765-4813-8f34-3aff6a1be1ac"> | 

### CustomCodable
| |  |
| --- | --- |
| Before | <img width="675" alt="image" src="https://github.com/DougGregor/swift-macro-examples/assets/41236155/e0f7936f-d32f-4ef0-ac77-992abd346156"> |
| After | <img width="675" alt="스크린샷 2023-06-15 오전 9 00 25" src="https://github.com/DougGregor/swift-macro-examples/assets/41236155/fe37a59b-942b-427f-8d1b-8d22307ef576"> |
