### PR TITLE
Update Xcode project to use the Swift package as a local dependency

### DIFF
--- a/MacroExamples.xcodeproj/project.pbxproj
+++ b/MacroExamples.xcodeproj/project.pbxproj
@@ -3,67 +3,13 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 56;
+	objectVersion = 60;
 	objects = {
 
 /* Begin PBXBuildFile section */
-		1D682A92299CE4C6006F9F78 /* AddAsyncMacro.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D682A91299CE4C6006F9F78 /* AddAsyncMacro.swift */; };
-		1D682A94299E2FFB006F9F78 /* CodableKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D682A93299E2FFB006F9F78 /* CodableKey.swift */; };
-		1D682A96299E3313006F9F78 /* CustomCodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D682A95299E3313006F9F78 /* CustomCodable.swift */; };
-		3175781D298DBC8700D79290 /* NewTypeMacro.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3175781C298DBC8700D79290 /* NewTypeMacro.swift */; };
-		3175781F298DBFA100D79290 /* NewTypePluginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3175781E298DBFA100D79290 /* NewTypePluginTests.swift */; };
-		31757821298DC4AF00D79290 /* NewType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31757820298DC4AF00D79290 /* NewType.swift */; };
-		371A6719299C241F00E74A8A /* CaseDetectionMacro.swift in Sources */ = {isa = PBXBuildFile; fileRef = 371A6718299C241F00E74A8A /* CaseDetectionMacro.swift */; };
-		88E54A5229B5475400252D99 /* MetaEnumMacro.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88E54A5129B5475400252D99 /* MetaEnumMacro.swift */; };
-		88E54A5429B5520A00252D99 /* MetaEnumMacroTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88E54A5329B5520A00252D99 /* MetaEnumMacroTests.swift */; };
-		911F5F8829BB5A150081AF9C /* URLMacro.swift in Sources */ = {isa = PBXBuildFile; fileRef = 911F5F8729BB5A150081AF9C /* URLMacro.swift */; };
-		BD2CDEE9298B24040015A701 /* Diagnostics.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD2CDEE8298B24040015A701 /* Diagnostics.swift */; };
-		BD2CDEEB298B34730015A701 /* WrapStoredPropertiesMacro.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD2CDEEA298B34730015A701 /* WrapStoredPropertiesMacro.swift */; };
-		BD2CDEED298B4A650015A701 /* DictionaryIndirectionMacro.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD2CDEEC298B4A650015A701 /* DictionaryIndirectionMacro.swift */; };
-		BD48319329AFF87200F3123A /* OptionSetMacro.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD48319229AFF87200F3123A /* OptionSetMacro.swift */; };
-		BD7324B829989178009C6A08 /* AddCompletionHandlerMacro.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD7324B729989178009C6A08 /* AddCompletionHandlerMacro.swift */; };
-		BD752BE5294D3BEC00D00A2E /* WarningMacro.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD752BE4294D3BEC00D00A2E /* WarningMacro.swift */; };
-		BD752BE7294D461B00D00A2E /* FontLiteralMacro.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD752BE6294D461B00D00A2E /* FontLiteralMacro.swift */; };
-		BD841F82294CE1F600DA4D81 /* AddBlocker.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD841F81294CE1F600DA4D81 /* AddBlocker.swift */; };
-		BD8A3130294947BD00E83EB9 /* Macros.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD8A312F294947BD00E83EB9 /* Macros.swift */; };
-		BD8A31312949480600E83EB9 /* libMacroExamplesLib.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = BD8A3126294947A100E83EB9 /* libMacroExamplesLib.dylib */; };
 		BDF5AFE42947E5B000FA119B /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDF5AFE32947E5B000FA119B /* main.swift */; };
-		BDF5AFF82947E95C00FA119B /* StringifyMacro.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDF5AFF72947E95C00FA119B /* StringifyMacro.swift */; };
-		BDFB14B52948484000708DA6 /* MacroExamplesPluginTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDFB14B42948484000708DA6 /* MacroExamplesPluginTest.swift */; };
-		BDFB14B62948484000708DA6 /* libMacroExamplesPlugin.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = BDF5AFEE2947E61100FA119B /* libMacroExamplesPlugin.dylib */; platformFilters = (macos, ); };
-		EC21BDEB298D9F9900D585C6 /* ObservableMacro.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC21BDEA298D9F9900D585C6 /* ObservableMacro.swift */; };
+		DA9FEE9D2A57709F00CC25F3 /* MacroExamplesLib in Frameworks */ = {isa = PBXBuildFile; productRef = DA9FEE9C2A57709F00CC25F3 /* MacroExamplesLib */; };
 /* End PBXBuildFile section */
-
-/* Begin PBXContainerItemProxy section */
-		BD8A31322949480C00E83EB9 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BDF5AFD82947E5B000FA119B /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = BD8A3125294947A100E83EB9;
-			remoteInfo = MacroExamplesLib;
-		};
-		BD8A31342949480C00E83EB9 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BDF5AFD82947E5B000FA119B /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = BDF5AFED2947E61100FA119B;
-			remoteInfo = MacroExamplesPlugin;
-		};
-		BD8A313629494C4C00E83EB9 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BDF5AFD82947E5B000FA119B /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = BDF5AFED2947E61100FA119B;
-			remoteInfo = MacroExamplesPlugin;
-		};
-		BDFB14B72948484000708DA6 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BDF5AFD82947E5B000FA119B /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = BDF5AFED2947E61100FA119B;
-			remoteInfo = MacroExamplesPlugin;
-		};
-/* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
 		BDF5AFDE2947E5B000FA119B /* CopyFiles */ = {
@@ -78,111 +24,28 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		1D682A91299CE4C6006F9F78 /* AddAsyncMacro.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddAsyncMacro.swift; sourceTree = "<group>"; };
-		1D682A93299E2FFB006F9F78 /* CodableKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodableKey.swift; sourceTree = "<group>"; };
-		1D682A95299E3313006F9F78 /* CustomCodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomCodable.swift; sourceTree = "<group>"; };
-		3175781C298DBC8700D79290 /* NewTypeMacro.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewTypeMacro.swift; sourceTree = "<group>"; };
-		3175781E298DBFA100D79290 /* NewTypePluginTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewTypePluginTests.swift; sourceTree = "<group>"; };
-		31757820298DC4AF00D79290 /* NewType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewType.swift; sourceTree = "<group>"; };
-		371A6718299C241F00E74A8A /* CaseDetectionMacro.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaseDetectionMacro.swift; sourceTree = "<group>"; };
-		88E54A5129B5475400252D99 /* MetaEnumMacro.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetaEnumMacro.swift; sourceTree = "<group>"; };
-		88E54A5329B5520A00252D99 /* MetaEnumMacroTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetaEnumMacroTests.swift; sourceTree = "<group>"; };
-		911F5F8729BB5A150081AF9C /* URLMacro.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URLMacro.swift; sourceTree = "<group>"; };
-		BD2CDEE8298B24040015A701 /* Diagnostics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Diagnostics.swift; sourceTree = "<group>"; };
-		BD2CDEEA298B34730015A701 /* WrapStoredPropertiesMacro.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WrapStoredPropertiesMacro.swift; sourceTree = "<group>"; };
-		BD2CDEEC298B4A650015A701 /* DictionaryIndirectionMacro.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryIndirectionMacro.swift; sourceTree = "<group>"; };
 		BD3FE05C296611F200426C82 /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
-		BD48319229AFF87200F3123A /* OptionSetMacro.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptionSetMacro.swift; sourceTree = "<group>"; };
-		BD7324B729989178009C6A08 /* AddCompletionHandlerMacro.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddCompletionHandlerMacro.swift; sourceTree = "<group>"; };
-		BD752BE4294D3BEC00D00A2E /* WarningMacro.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WarningMacro.swift; sourceTree = "<group>"; };
-		BD752BE6294D461B00D00A2E /* FontLiteralMacro.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontLiteralMacro.swift; sourceTree = "<group>"; };
-		BD841F81294CE1F600DA4D81 /* AddBlocker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddBlocker.swift; sourceTree = "<group>"; };
-		BD8A3126294947A100E83EB9 /* libMacroExamplesLib.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = libMacroExamplesLib.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
-		BD8A312F294947BD00E83EB9 /* Macros.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Macros.swift; sourceTree = "<group>"; };
 		BDF5AFE02947E5B000FA119B /* MacroExamples */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = MacroExamples; sourceTree = BUILT_PRODUCTS_DIR; };
 		BDF5AFE32947E5B000FA119B /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
-		BDF5AFEE2947E61100FA119B /* libMacroExamplesPlugin.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = libMacroExamplesPlugin.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
-		BDF5AFF72947E95C00FA119B /* StringifyMacro.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = StringifyMacro.swift; path = MacroExamplesPlugin/StringifyMacro.swift; sourceTree = SOURCE_ROOT; };
-		BDFB14B22948484000708DA6 /* MacroExamplesPluginTest.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MacroExamplesPluginTest.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		BDFB14B42948484000708DA6 /* MacroExamplesPluginTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacroExamplesPluginTest.swift; sourceTree = "<group>"; };
-		EC21BDEA298D9F9900D585C6 /* ObservableMacro.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObservableMacro.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		BD8A3124294947A100E83EB9 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		BDF5AFDD2947E5B000FA119B /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BD8A31312949480600E83EB9 /* libMacroExamplesLib.dylib in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		BDF5AFEC2947E61100FA119B /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		BDFB14AF2948484000708DA6 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				BDFB14B62948484000708DA6 /* libMacroExamplesPlugin.dylib in Frameworks */,
+				DA9FEE9D2A57709F00CC25F3 /* MacroExamplesLib in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		BD841F80294CE14500DA4D81 /* MacroExamplesPlugin */ = {
-			isa = PBXGroup;
-			children = (
-				911F5F8729BB5A150081AF9C /* URLMacro.swift */,
-				BDF5AFF72947E95C00FA119B /* StringifyMacro.swift */,
-				BD841F81294CE1F600DA4D81 /* AddBlocker.swift */,
-				BD752BE4294D3BEC00D00A2E /* WarningMacro.swift */,
-				BD752BE6294D461B00D00A2E /* FontLiteralMacro.swift */,
-				EC21BDEA298D9F9900D585C6 /* ObservableMacro.swift */,
-				BD2CDEE8298B24040015A701 /* Diagnostics.swift */,
-				BD2CDEEA298B34730015A701 /* WrapStoredPropertiesMacro.swift */,
-				BD2CDEEC298B4A650015A701 /* DictionaryIndirectionMacro.swift */,
-				3175781C298DBC8700D79290 /* NewTypeMacro.swift */,
-				BD7324B729989178009C6A08 /* AddCompletionHandlerMacro.swift */,
-				371A6718299C241F00E74A8A /* CaseDetectionMacro.swift */,
-				1D682A91299CE4C6006F9F78 /* AddAsyncMacro.swift */,
-				1D682A93299E2FFB006F9F78 /* CodableKey.swift */,
-				1D682A95299E3313006F9F78 /* CustomCodable.swift */,
-				BD48319229AFF87200F3123A /* OptionSetMacro.swift */,
-				88E54A5129B5475400252D99 /* MetaEnumMacro.swift */,
-			);
-			path = MacroExamplesPlugin;
-			sourceTree = "<group>";
-		};
-		BD8A3127294947A100E83EB9 /* MacroExamplesLib */ = {
-			isa = PBXGroup;
-			children = (
-				BD8A312F294947BD00E83EB9 /* Macros.swift */,
-				31757820298DC4AF00D79290 /* NewType.swift */,
-			);
-			path = MacroExamplesLib;
-			sourceTree = "<group>";
-		};
 		BDF5AFD72947E5B000FA119B = {
 			isa = PBXGroup;
 			children = (
 				BD3FE05C296611F200426C82 /* README.md */,
-				BD841F80294CE14500DA4D81 /* MacroExamplesPlugin */,
 				BDF5AFE22947E5B000FA119B /* MacroExamples */,
-				BDFB14B32948484000708DA6 /* MacroExamplesPluginTest */,
-				BD8A3127294947A100E83EB9 /* MacroExamplesLib */,
 				BDF5AFE12947E5B000FA119B /* Products */,
 				BDF5B0162947FE1A00FA119B /* Frameworks */,
 			);
@@ -193,9 +56,6 @@
 			isa = PBXGroup;
 			children = (
 				BDF5AFE02947E5B000FA119B /* MacroExamples */,
-				BDF5AFEE2947E61100FA119B /* libMacroExamplesPlugin.dylib */,
-				BDFB14B22948484000708DA6 /* MacroExamplesPluginTest.xctest */,
-				BD8A3126294947A100E83EB9 /* libMacroExamplesLib.dylib */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -215,54 +75,9 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
-		BDFB14B32948484000708DA6 /* MacroExamplesPluginTest */ = {
-			isa = PBXGroup;
-			children = (
-				BDFB14B42948484000708DA6 /* MacroExamplesPluginTest.swift */,
-				3175781E298DBFA100D79290 /* NewTypePluginTests.swift */,
-				88E54A5329B5520A00252D99 /* MetaEnumMacroTests.swift */,
-			);
-			path = MacroExamplesPluginTest;
-			sourceTree = "<group>";
-		};
 /* End PBXGroup section */
 
-/* Begin PBXHeadersBuildPhase section */
-		BD8A3122294947A100E83EB9 /* Headers */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		BDF5AFEA2947E61100FA119B /* Headers */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXHeadersBuildPhase section */
-
 /* Begin PBXNativeTarget section */
-		BD8A3125294947A100E83EB9 /* MacroExamplesLib */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = BD8A312C294947A100E83EB9 /* Build configuration list for PBXNativeTarget "MacroExamplesLib" */;
-			buildPhases = (
-				BD8A3122294947A100E83EB9 /* Headers */,
-				BD8A3123294947A100E83EB9 /* Sources */,
-				BD8A3124294947A100E83EB9 /* Frameworks */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				BD8A313729494C4C00E83EB9 /* PBXTargetDependency */,
-			);
-			name = MacroExamplesLib;
-			productName = MacroExamplesLib;
-			productReference = BD8A3126294947A100E83EB9 /* libMacroExamplesLib.dylib */;
-			productType = "com.apple.product-type.library.dynamic";
-		};
 		BDF5AFDF2947E5B000FA119B /* MacroExamples */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = BDF5AFE72947E5B000FA119B /* Build configuration list for PBXNativeTarget "MacroExamples" */;
@@ -274,52 +89,14 @@
 			buildRules = (
 			);
 			dependencies = (
-				BD8A31332949480C00E83EB9 /* PBXTargetDependency */,
-				BD8A31352949480C00E83EB9 /* PBXTargetDependency */,
 			);
 			name = MacroExamples;
 			packageProductDependencies = (
+				DA9FEE9C2A57709F00CC25F3 /* MacroExamplesLib */,
 			);
 			productName = MacroExamples;
 			productReference = BDF5AFE02947E5B000FA119B /* MacroExamples */;
 			productType = "com.apple.product-type.tool";
-		};
-		BDF5AFED2947E61100FA119B /* MacroExamplesPlugin */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = BDF5AFF42947E61100FA119B /* Build configuration list for PBXNativeTarget "MacroExamplesPlugin" */;
-			buildPhases = (
-				BDF5AFEA2947E61100FA119B /* Headers */,
-				BDF5AFEB2947E61100FA119B /* Sources */,
-				BDF5AFEC2947E61100FA119B /* Frameworks */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = MacroExamplesPlugin;
-			packageProductDependencies = (
-			);
-			productName = MacroExamplesPlugin;
-			productReference = BDF5AFEE2947E61100FA119B /* libMacroExamplesPlugin.dylib */;
-			productType = "com.apple.product-type.library.dynamic";
-		};
-		BDFB14B12948484000708DA6 /* MacroExamplesPluginTest */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = BDFB14B92948484000708DA6 /* Build configuration list for PBXNativeTarget "MacroExamplesPluginTest" */;
-			buildPhases = (
-				BDFB14AE2948484000708DA6 /* Sources */,
-				BDFB14AF2948484000708DA6 /* Frameworks */,
-				BDFB14B02948484000708DA6 /* Resources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				BDFB14B82948484000708DA6 /* PBXTargetDependency */,
-			);
-			name = MacroExamplesPluginTest;
-			productName = MacroExamplesPluginTest;
-			productReference = BDFB14B22948484000708DA6 /* MacroExamplesPluginTest.xctest */;
-			productType = "com.apple.product-type.bundle.unit-test";
 		};
 /* End PBXNativeTarget section */
 
@@ -331,18 +108,7 @@
 				LastSwiftUpdateCheck = 1430;
 				LastUpgradeCheck = 1430;
 				TargetAttributes = {
-					BD8A3125294947A100E83EB9 = {
-						CreatedOnToolsVersion = 14.3;
-						LastSwiftMigration = 1430;
-					};
 					BDF5AFDF2947E5B000FA119B = {
-						CreatedOnToolsVersion = 14.3;
-					};
-					BDF5AFED2947E61100FA119B = {
-						CreatedOnToolsVersion = 14.3;
-						LastSwiftMigration = 1430;
-					};
-					BDFB14B12948484000708DA6 = {
 						CreatedOnToolsVersion = 14.3;
 					};
 				};
@@ -357,39 +123,18 @@
 			);
 			mainGroup = BDF5AFD72947E5B000FA119B;
 			packageReferences = (
+				DA9FEE9B2A57709F00CC25F3 /* XCLocalSwiftPackageReference "" */,
 			);
 			productRefGroup = BDF5AFE12947E5B000FA119B /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
 				BDF5AFDF2947E5B000FA119B /* MacroExamples */,
-				BDF5AFED2947E61100FA119B /* MacroExamplesPlugin */,
-				BDFB14B12948484000708DA6 /* MacroExamplesPluginTest */,
-				BD8A3125294947A100E83EB9 /* MacroExamplesLib */,
 			);
 		};
 /* End PBXProject section */
 
-/* Begin PBXResourcesBuildPhase section */
-		BDFB14B02948484000708DA6 /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXResourcesBuildPhase section */
-
 /* Begin PBXSourcesBuildPhase section */
-		BD8A3123294947A100E83EB9 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				BD8A3130294947BD00E83EB9 /* Macros.swift in Sources */,
-				31757821298DC4AF00D79290 /* NewType.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		BDF5AFDC2947E5B000FA119B /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -398,104 +143,9 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		BDF5AFEB2947E61100FA119B /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				BD841F82294CE1F600DA4D81 /* AddBlocker.swift in Sources */,
-				BD2CDEEB298B34730015A701 /* WrapStoredPropertiesMacro.swift in Sources */,
-				1D682A94299E2FFB006F9F78 /* CodableKey.swift in Sources */,
-				371A6719299C241F00E74A8A /* CaseDetectionMacro.swift in Sources */,
-				BD752BE5294D3BEC00D00A2E /* WarningMacro.swift in Sources */,
-				3175781D298DBC8700D79290 /* NewTypeMacro.swift in Sources */,
-				BDF5AFF82947E95C00FA119B /* StringifyMacro.swift in Sources */,
-				EC21BDEB298D9F9900D585C6 /* ObservableMacro.swift in Sources */,
-				88E54A5229B5475400252D99 /* MetaEnumMacro.swift in Sources */,
-				BD2CDEE9298B24040015A701 /* Diagnostics.swift in Sources */,
-				1D682A96299E3313006F9F78 /* CustomCodable.swift in Sources */,
-				BD2CDEED298B4A650015A701 /* DictionaryIndirectionMacro.swift in Sources */,
-				BD752BE7294D461B00D00A2E /* FontLiteralMacro.swift in Sources */,
-				BD7324B829989178009C6A08 /* AddCompletionHandlerMacro.swift in Sources */,
-				BD48319329AFF87200F3123A /* OptionSetMacro.swift in Sources */,
-				911F5F8829BB5A150081AF9C /* URLMacro.swift in Sources */,
-				1D682A92299CE4C6006F9F78 /* AddAsyncMacro.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		BDFB14AE2948484000708DA6 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				BDFB14B52948484000708DA6 /* MacroExamplesPluginTest.swift in Sources */,
-				3175781F298DBFA100D79290 /* NewTypePluginTests.swift in Sources */,
-				88E54A5429B5520A00252D99 /* MetaEnumMacroTests.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 /* End PBXSourcesBuildPhase section */
 
-/* Begin PBXTargetDependency section */
-		BD8A31332949480C00E83EB9 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = BD8A3125294947A100E83EB9 /* MacroExamplesLib */;
-			targetProxy = BD8A31322949480C00E83EB9 /* PBXContainerItemProxy */;
-		};
-		BD8A31352949480C00E83EB9 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = BDF5AFED2947E61100FA119B /* MacroExamplesPlugin */;
-			targetProxy = BD8A31342949480C00E83EB9 /* PBXContainerItemProxy */;
-		};
-		BD8A313729494C4C00E83EB9 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = BDF5AFED2947E61100FA119B /* MacroExamplesPlugin */;
-			targetProxy = BD8A313629494C4C00E83EB9 /* PBXContainerItemProxy */;
-		};
-		BDFB14B82948484000708DA6 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			platformFilters = (
-				macos,
-			);
-			target = BDF5AFED2947E61100FA119B /* MacroExamplesPlugin */;
-			targetProxy = BDFB14B72948484000708DA6 /* PBXContainerItemProxy */;
-		};
-/* End PBXTargetDependency section */
-
 /* Begin XCBuildConfiguration section */
-		BD8A312D294947A100E83EB9 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_STYLE = Automatic;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				EXECUTABLE_PREFIX = lib;
-				MACH_O_TYPE = staticlib;
-				MACOSX_DEPLOYMENT_TARGET = 12.0;
-				OTHER_SWIFT_FLAGS = "-Xfrontend -enable-experimental-feature -Xfrontend Macros -Xfrontend -load-plugin-library -Xfrontend ${BUILD_DIR}/${CONFIGURATION}/libMacroExamplesPlugin.dylib";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SKIP_INSTALL = YES;
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 5.0;
-			};
-			name = Debug;
-		};
-		BD8A312E294947A100E83EB9 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_STYLE = Automatic;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				EXECUTABLE_PREFIX = lib;
-				MACH_O_TYPE = staticlib;
-				MACOSX_DEPLOYMENT_TARGET = 12.0;
-				OTHER_SWIFT_FLAGS = "-Xfrontend -enable-experimental-feature -Xfrontend Macros -Xfrontend -load-plugin-library -Xfrontend ${BUILD_DIR}/${CONFIGURATION}/libMacroExamplesPlugin.dylib";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 5.0;
-			};
-			name = Release;
-		};
 		BDF5AFE52947E5B000FA119B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -615,7 +265,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				OTHER_SWIFT_FLAGS = "-Xfrontend -enable-experimental-feature -Xfrontend Macros -Xfrontend -load-plugin-library -Xfrontend ${BUILD_DIR}/${CONFIGURATION}/libMacroExamplesPlugin.dylib -Xfrontend -dump-macro-expansions";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				"SWIFT_OPTIMIZATION_LEVEL[arch=*]" = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -626,107 +275,14 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				OTHER_SWIFT_FLAGS = "-Xfrontend -enable-experimental-feature -Xfrontend Macros -Xfrontend -load-plugin-library -Xfrontend ${BUILD_DIR}/${CONFIGURATION}/libMacroExamplesPlugin.dylib -Xfrontend -dump-macro-expansions";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
-			};
-			name = Release;
-		};
-		BDF5AFF52947E61100FA119B /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_STYLE = Automatic;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				EXECUTABLE_PREFIX = lib;
-				LD_RUNPATH_SEARCH_PATHS = "$(TOOLCHAIN_DIR)/usr/lib/swift/host";
-				LIBRARY_SEARCH_PATHS = "$(TOOLCHAIN_DIR)/usr/lib/swift/host";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SKIP_INSTALL = YES;
-				SWIFT_INCLUDE_PATHS = "$(TOOLCHAIN_DIR)/usr/lib/swift/host";
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 5.0;
-			};
-			name = Debug;
-		};
-		BDF5AFF62947E61100FA119B /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_STYLE = Automatic;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				EXECUTABLE_PREFIX = lib;
-				LD_RUNPATH_SEARCH_PATHS = "$(TOOLCHAIN_DIR)/usr/lib/swift/host";
-				LIBRARY_SEARCH_PATHS = "$(TOOLCHAIN_DIR)/usr/lib/swift/host";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SKIP_INSTALL = YES;
-				SWIFT_INCLUDE_PATHS = "$(TOOLCHAIN_DIR)/usr/lib/swift/host";
-				SWIFT_VERSION = 5.0;
-			};
-			name = Release;
-		};
-		BDFB14BA2948484000708DA6 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
-				GENERATE_INFOPLIST_FILE = YES;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(LD_RUNPATH_SEARCH_PATHS_SHALLOW_BUNDLE_$(SHALLOW_BUNDLE))",
-					"$(TOOLCHAIN_DIR)/usr/lib/swift/host",
-				);
-				LIBRARY_SEARCH_PATHS = "$(TOOLCHAIN_DIR)/usr/lib/swift/host";
-				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = Apple.MacroExamplesPluginTest;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = auto;
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
-				SWIFT_EMIT_LOC_STRINGS = NO;
-				SWIFT_INCLUDE_PATHS = "$(TOOLCHAIN_DIR)/usr/lib/swift/host";
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = Debug;
-		};
-		BDFB14BB2948484000708DA6 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
-				GENERATE_INFOPLIST_FILE = YES;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(LD_RUNPATH_SEARCH_PATHS_SHALLOW_BUNDLE_$(SHALLOW_BUNDLE))",
-					"$(TOOLCHAIN_DIR)/usr/lib/swift/host",
-				);
-				LIBRARY_SEARCH_PATHS = "$(TOOLCHAIN_DIR)/usr/lib/swift/host";
-				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = Apple.MacroExamplesPluginTest;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = auto;
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
-				SWIFT_EMIT_LOC_STRINGS = NO;
-				SWIFT_INCLUDE_PATHS = "$(TOOLCHAIN_DIR)/usr/lib/swift/host";
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
 		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		BD8A312C294947A100E83EB9 /* Build configuration list for PBXNativeTarget "MacroExamplesLib" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				BD8A312D294947A100E83EB9 /* Debug */,
-				BD8A312E294947A100E83EB9 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
 		BDF5AFDB2947E5B000FA119B /* Build configuration list for PBXProject "MacroExamples" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -745,25 +301,21 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		BDF5AFF42947E61100FA119B /* Build configuration list for PBXNativeTarget "MacroExamplesPlugin" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				BDF5AFF52947E61100FA119B /* Debug */,
-				BDF5AFF62947E61100FA119B /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		BDFB14B92948484000708DA6 /* Build configuration list for PBXNativeTarget "MacroExamplesPluginTest" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				BDFB14BA2948484000708DA6 /* Debug */,
-				BDFB14BB2948484000708DA6 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
 /* End XCConfigurationList section */
+
+/* Begin XCLocalSwiftPackageReference section */
+		DA9FEE9B2A57709F00CC25F3 /* XCLocalSwiftPackageReference "" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = "";
+		};
+/* End XCLocalSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		DA9FEE9C2A57709F00CC25F3 /* MacroExamplesLib */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = MacroExamplesLib;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = BDF5AFD82947E5B000FA119B /* Project object */;
 }

--- a/MacroExamples.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/MacroExamples.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -2,6 +2,6 @@
 <Workspace
    version = "1.0">
    <FileRef
-      location = "self:/Users/dgregor/Projects/Macros/MacroExamples/MacroExamples.xcodeproj">
+      location = "self:">
    </FileRef>
 </Workspace>

--- a/README.md
+++ b/README.md
@@ -1,22 +1,21 @@
 # Swift Macro Examples
 
-
-
-There is an active effort to introduce [macros](https://forums.swift.org/t/a-possible-vision-for-macros-in-swift/60900) into the Swift programming language. This repository includes some example macros that can be used to explore the macro proposals and experiment with the current implementation of the feature. 
+There is an active effort to introduce [macros](https://forums.swift.org/t/a-possible-vision-for-macros-in-swift/60900) into the Swift programming language. This repository includes some example macros that can be used to explore the macro proposals and experiment with the current implementation of the feature.
 
 ## Getting started
 
 Macros are an experimental feature, so you will need a custom Swift toolchain and some extra compiler flags. The Xcode project in this repository is a good starting point. To use it:
 
 1. Download a [development snapshot](https://www.swift.org/download/#snapshots) of the compiler from Swift.org from May 10, 2023 or later. At present, we only have these working on macOS, but are working to get other platforms working with other build systems.
-2. To use SwiftPM to build the example project, use `swift build` from the toolchain, e.g.:
+2. Use SwiftPM to build the example project via `swift build` from the toolchain, e.g.:
    ```
    /Library/Developer/Toolchains/swift-DEVELOPMENT-SNAPSHOT-2023-03-08-a.xctoolchain/usr/bin/swift build
    ```
-3. To use Xcode to build the example project:
-  a. Open `MacroExamples.xcodeproj` in Xcode
-  b. Go to the Xcode -> Toolchains menu and select the development toolchain you downloaded.
-  c. Make sure the `MacroExamples` scheme is selected, then build and run! If the first build fails, build again--there's something funky going on with the dependencies. Then build again!
+
+You can also open, build, and run this project in Xcode itself:
+  - Open `Package.swift` in Xcode
+  - Go to the Xcode -> Toolchains menu and select the development toolchain you downloaded.
+  - Build and run!
 
 The output of the `MacroExamples` program is pretty simple: it shows the result of running the example macro(s). The `main.swift` file is annotated to describe what the macros are actually doing.
 


### PR DESCRIPTION
SwiftPM is the supported method of creating a macro plugin. Remove the Xcode project's `Other Swift Flags` and build the plugin through the package instead. This is a little weird as we have `MacroExamples` as a target in both the project and the package - we could remove the project entirely, but it seems nice to still have it with the package dependency as an example.